### PR TITLE
chore: Enum name normalization

### DIFF
--- a/python/dataset-experiments/app.py
+++ b/python/dataset-experiments/app.py
@@ -1,7 +1,7 @@
 from galileo.prompts import get_prompt_template, create_prompt_template
 from galileo.experiments import run_experiment
 from galileo.datasets import get_dataset
-from galileo.resources.models import MessageRole, Message
+from galileo_core.schemas.logging.llm import Message, MessageRole
 from dotenv import load_dotenv
 
 load_dotenv()


### PR DESCRIPTION
### Summary

[Shortcut #27505: Standardize the message role enum](https://app.shortcut.com/galileo/story/27505/g2-0-python-sdk-standardize-the-messagerole-models)

### Details

[Searching](https://github.com/search?q=org%3Arungalileo+%2F%28%3F-i%29MessageRole%5C.%5BA-Z%5D%2F&type=code) github references for cases where `MessageRole` enum name has upper casing lead us to this repo. The changes made here will make the naming consistent across the board.