### PR TITLE
fix: Update to import Message and MessageRole from galileo package

### DIFF
--- a/python/dataset-experiments/app.py
+++ b/python/dataset-experiments/app.py
@@ -1,7 +1,7 @@
+from galileo import Message, MessageRole
 from galileo.prompts import get_prompt_template, create_prompt_template
 from galileo.experiments import run_experiment
 from galileo.datasets import get_dataset
-from galileo.resources.models import MessageRole, Message
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -14,8 +14,8 @@ if prompt_template is None:
         name="geography-prompt",
         project=project,
         messages=[
-            Message(role=MessageRole.SYSTEM, content="You are a geography expert. Respond with only the continent name."),
-            Message(role=MessageRole.USER, content="{{input}}")
+            Message(role=MessageRole.system, content="You are a geography expert. Respond with only the continent name."),
+            Message(role=MessageRole.user, content="{{input}}")
         ]
     )
 


### PR DESCRIPTION
### Summary

We ensured the right `Message` and `MessageRole` models can be imported directly from `galileo` package in this [update](https://github.com/rungalileo/galileo-python/pull/99) to the SDK. This PR updates the examples to ensure we import from the right place.