### PR TITLE
Bumping Python version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ If you submit a PR to the SDK examples repo — please make sure to either open 
 1. **Galileo.ai Account**: You'll need a free account on [Galileo.ai](https://app.galileo.ai/sign-up)
 2. **API Key**: Obtain your API key from the [Galileo.ai dashboard](https://app.galileo.ai/settings/api-keys)
 3. **Development Environment**: 
-   - For Python examples: Preferred Python 3.8+ (Galileo supports Python <3.14, >=3.9) 
+   - For Python examples: Preferred Python 3.10+ (Galileo supports Python <3.14, >=3.10)
    - For TypeScript examples: Node.js 16+ and npm/yarn
 
 ### Setup
@@ -152,7 +152,7 @@ Explain any configuration options or settings.
 
 ### Python Standards
 
-- **Python Version**: Target Python <3.14, >=3.9
+- **Python Version**: Target Python <3.14, >=3.10
 - **Code Style**: Follow PEP 8 guidelines
 - **Dependencies**: Use `requirements.txt` 
 - **Type Hints**: Include type hints for function parameters and return values

--- a/python/agent/crew-ai/README.md
+++ b/python/agent/crew-ai/README.md
@@ -5,7 +5,7 @@ Its main purpose is to showcase how to set up a project with open-inference and 
 
 ## Getting Started
 
-To get started with this project, you'll need to have Python 3.9 or later installed. You can then install the required dependencies using Poetry:
+To get started with this project, you'll need to have Python 3.10 or later installed. You can then install the required dependencies using Poetry:
 
 ```sync
 uv sync

--- a/python/agent/google-adk/README.md
+++ b/python/agent/google-adk/README.md
@@ -4,7 +4,7 @@ This is an example project demonstrating how to use Galileo with the Google ADK.
 
 ## Getting Started
 
-To get started with this project, you'll need to have Python 3.9 or later installed. You can then install the required dependencies in a virtual environment:
+To get started with this project, you'll need to have Python 3.10 or later installed. You can then install the required dependencies in a virtual environment:
 
 ```bash
 pip install -r requirements.txt

--- a/python/agent/langgraph-fsi-agent/before/poetry.lock
+++ b/python/agent/langgraph-fsi-agent/before/poetry.lock
@@ -4476,7 +4476,7 @@ tenacity = ">=8.2.3,<10.0"
 [[package]]
 name = "typing-extensions"
 version = "4.14.1"
-description = "Backported and Experimental Type Hints for Python 3.9+"
+description = "Backported and Experimental Type Hints for Python 3.10+"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]

--- a/python/agent/langgraph-otel/README.md
+++ b/python/agent/langgraph-otel/README.md
@@ -11,7 +11,7 @@ For detailed explanations and advanced patterns, see the [LangGraph OpenTelemetr
 ## Quick start
 
 ### Prerequisites
-- Python 3.9+
+- Python 3.10+
 - [UV package manager](https://docs.astral.sh/uv/getting-started/installation/)
 - [Galileo account](https://app.galileo.ai) (free)
 - OpenAI API key

--- a/python/agent/langgraph-telecom-agent/README.md
+++ b/python/agent/langgraph-telecom-agent/README.md
@@ -95,7 +95,7 @@ Since this is a demo system without live telecom APIs, all tools use mock data g
 
 ### Prerequisites
 
-- Python 3.9+
+- Python 3.10+
 - [OpenAI API Key](https://platform.openai.com/api-keys)
 - [Pinecone Account](https://www.pinecone.io) 
 - [Galileo Account](https://app.galileo.ai/sign-up) 

--- a/python/agent/startup-simulator-3000/README.md
+++ b/python/agent/startup-simulator-3000/README.md
@@ -46,7 +46,7 @@ run immediately!
 
 Make sure you have:
 
-- **Python 3.9+** installed on your system
+- **Python 3.10+** installed on your system
 - **Git** (optional, for cloning)
 - **A code editor** (VS Code, PyCharm, etc.)
 
@@ -280,7 +280,7 @@ If you run into issues:
 1. Check the troubleshooting section above
 2. Look at the terminal logs for error messages
 3. Verify your API keys are correct
-4. Make sure you're using Python 3.9+
+4. Make sure you're using Python 3.10+
 
 ---
 

--- a/python/agent/startup-simulator-3000/TUTORIAL.md
+++ b/python/agent/startup-simulator-3000/TUTORIAL.md
@@ -431,7 +431,7 @@ gunicorn -w 4 -b 0.0.0.0:2021 app:app
 
 3. **Docker Deployment**
 ```dockerfile
-FROM python:3.9-slim
+FROM python:3.10-slim
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/python/agent/strands-agents/README.md
+++ b/python/agent/strands-agents/README.md
@@ -4,7 +4,7 @@ This is an example project demonstrating how to use Galileo with the [Strands Ag
 
 ## Getting Started
 
-To get started with this project, you'll need to have Python 3.9 or later installed. You can then install the required dependencies in a virtual environment:
+To get started with this project, you'll need to have Python 3.10 or later installed. You can then install the required dependencies in a virtual environment:
 
 ```bash
 pip install -r requirements.txt

--- a/python/chatbot/sample-project-chatbot/anthropic/README.md
+++ b/python/chatbot/sample-project-chatbot/anthropic/README.md
@@ -12,7 +12,7 @@ This project also has a unit test that runs the chatbot using the Galileo experi
 
 To run this project you will need:
 
-- Python 3.9 or higher installed
+- Python 3.10 or higher installed
 - An Anthropic API key
 - A [Galileo account](https://app.galileo.ai/sign-up) with a project and Log stream set up
 

--- a/python/chatbot/sample-project-chatbot/azure-inference/README.md
+++ b/python/chatbot/sample-project-chatbot/azure-inference/README.md
@@ -12,7 +12,7 @@ This project also has a unit test that runs the chatbot using the Galileo experi
 
 To run this project you will need:
 
-- Python 3.9 or higher installed
+- Python 3.10 or higher installed
 - A model deployed to Azure AI Foundry using the AI inference API
 - A [Galileo account](https://app.galileo.ai/sign-up) with a project and Log stream set up
 

--- a/python/chatbot/sample-project-chatbot/openai-ollama/README.md
+++ b/python/chatbot/sample-project-chatbot/openai-ollama/README.md
@@ -12,7 +12,7 @@ This project also has a unit test that runs the chatbot using the Galileo experi
 
 To run this project you will need:
 
-- Python 3.9 or higher installed
+- Python 3.10 or higher installed
 - Access to an LLM API that supports the OpenAI API specification, such as an API key for the [OpenAI API](https://openai.com/api/), or [Ollama](https://ollama.com) installed locally.
 - A [Galileo account](https://app.galileo.ai/sign-up) with a project and Log stream set up
 

--- a/python/experiments/rag-and-tools/README.md
+++ b/python/experiments/rag-and-tools/README.md
@@ -6,7 +6,7 @@ This code is used in the [Run an experiment against a RAG app](http://v2docs.gal
 
 ## Get Started
 
-To get started with this project, you'll need to have Python 3.9 or later installed. You can then install the required dependencies in a virtual environment:
+To get started with this project, you'll need to have Python 3.10 or later installed. You can then install the required dependencies in a virtual environment:
 
 ```bash
 pip install -r requirements.txt

--- a/python/logging-samples/log-mcp-calls/README.md
+++ b/python/logging-samples/log-mcp-calls/README.md
@@ -6,7 +6,7 @@ The MCP server used by default is the [Galileo MCP server](https://v2docs.galile
 
 ## Getting Started
 
-To get started with this project, you'll need to have Python 3.9 or later installed. You can then install the required dependencies in a virtual environment:
+To get started with this project, you'll need to have Python 3.10 or later installed. You can then install the required dependencies in a virtual environment:
 
 ```bash
 pip install -r requirements.txt


### PR DESCRIPTION
Chore - bumping minimum Python version to 3.10.

[SC-50455](https://app.shortcut.com/galileo/story/50455/bump-minimum-python-version-in-the-sdk-examples-to-3-10)
