### PR TITLE
chore: replace v2docs.galileo.ai with docs.galileo.ai

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # 🤝 Contributing to Galileo SDK Examples
 
-Thank you for your interest in contributing to the Galileo.ai SDK Examples repository! This guide will help you understand how to contribute effectively and maintain the quality of our examples. 
+Thank you for your interest in contributing to the Galileo.ai SDK Examples repository! This guide will help you understand how to contribute effectively and maintain the quality of our examples.
 
-If you submit a PR to the SDK examples repo — please make sure to either open an issue in the [Galileo Docs Official](https://github.com/rungalileo/docs-official) repo with details on how to use the application, or open a pull request with the completed cookbook so the feature can be added to the [Galileo Documentation](https://v2docs.galileo.ai/what-is-galileo) as well. 
+If you submit a PR to the SDK examples repo — please make sure to either open an issue in the [Galileo Docs Official](https://github.com/rungalileo/docs-official) repo with details on how to use the application, or open a pull request with the completed cookbook so the feature can be added to the [Galileo Documentation](https://docs.galileo.ai/what-is-galileo) as well.
 
 ## 📋 Table of contents
 
@@ -21,7 +21,7 @@ If you submit a PR to the SDK examples repo — please make sure to either open 
 
 1. **Galileo.ai Account**: You'll need a free account on [Galileo.ai](https://app.galileo.ai/sign-up)
 2. **API Key**: Obtain your API key from the [Galileo.ai dashboard](https://app.galileo.ai/settings/api-keys)
-3. **Development Environment**: 
+3. **Development Environment**:
    - For Python examples: Preferred Python 3.10+ (Galileo supports Python <3.14, >=3.10)
    - For TypeScript examples: Node.js 16+ and npm/yarn
 
@@ -62,6 +62,7 @@ sdk-examples/
 ### 1. Choose Your Category
 
 Examples should fit into one of these categories:
+
 - **Agent**: LLM systems that use tools and make decisions
 - **Chatbot**: Simple conversational applications
 - **RAG**: Retrieval-Augmented Generation applications
@@ -70,6 +71,7 @@ Examples should fit into one of these categories:
 ### 2. Create Your Example Directory
 
 Create a new directory following this naming convention:
+
 - Use kebab-case: `my-awesome-example`
 - Be descriptive but concise
 - Place in the appropriate language folder (`python/` or `typescript/`)
@@ -79,6 +81,7 @@ Create a new directory following this naming convention:
 Every example should include:
 
 #### For Python Examples:
+
 ```
 your-example/
 ├── README.md              # Documentation and setup instructions
@@ -89,6 +92,7 @@ your-example/
 ```
 
 #### For TypeScript Examples:
+
 ```
 your-example/
 ├── README.md              # Documentation and setup instructions
@@ -101,7 +105,7 @@ your-example/
 
 ### 4. Example README.md Template
 
-```markdown
+````markdown
 # Example Name
 
 Brief description of what this example demonstrates.
@@ -115,25 +119,29 @@ Brief description of what this example demonstrates.
 ## 🚀 Quick Start
 
 1. Install dependencies:
+
    ```bash
    # For Python
    pip install -r requirements.txt
-   
+
    # For TypeScript
    npm install
    ```
+````
 
 2. Set up environment variables:
+
    ```bash
    cp .env.example .env
    # Edit .env with your Galileo API key
    ```
 
 3. Run the example:
+
    ```bash
    # For Python
    python main.py
-   
+
    # For TypeScript
    npm start
    ```
@@ -144,9 +152,10 @@ Explain any configuration options or settings.
 
 ## 📚 Learn More
 
-- [Galileo.ai Documentation](https://v2docs.galileo.ai/)
+- [Galileo.ai Documentation](https://docs.galileo.ai/)
 - [Any Related Example Link](/path/to/related/example)
-```
+
+````
 
 ## 📝 Code Standards
 
@@ -154,7 +163,7 @@ Explain any configuration options or settings.
 
 - **Python Version**: Target Python <3.14, >=3.10
 - **Code Style**: Follow PEP 8 guidelines
-- **Dependencies**: Use `requirements.txt` 
+- **Dependencies**: Use `requirements.txt`
 - **Type Hints**: Include type hints for function parameters and return values
 - **Docstrings**: Add docstrings to functions and classes
 
@@ -165,28 +174,28 @@ from galileo import Galileo
 def process_data(data: List[str], config: Optional[dict] = None) -> dict:
     """
     Process the input data with Galileo integration.
-    
+
     Args:
         data: List of strings to process
         config: Optional configuration dictionary
-        
+
     Returns:
         Dictionary containing processed results
     """
     # Your code here
     pass
-```
+````
 
 ### TypeScript Standards
 
 - **Node.js Version**: Target Node.js 16+
 - **Code Style**: Use ESLint and Prettier
-- **Dependencies**: Use `package.json` 
+- **Dependencies**: Use `package.json`
 - **TypeScript**: Use strict mode and proper typing
 - **Comments**: Add JSDoc comments for functions
 
 ```typescript
-import { Galileo } from 'galileo';
+import { Galileo } from "galileo";
 
 interface ProcessConfig {
   enabled: boolean;
@@ -200,8 +209,8 @@ interface ProcessConfig {
  * @returns Promise resolving to processed results
  */
 async function processData(
-  data: string[], 
-  config?: ProcessConfig
+  data: string[],
+  config?: ProcessConfig,
 ): Promise<Record<string, any>> {
   // Your code here
 }
@@ -303,29 +312,35 @@ npm test
 
 ```markdown
 ## Description
+
 Brief description of what this example demonstrates.
 
 ## Type of Example
+
 - [ ] Agent
 - [ ] Chatbot
 - [ ] RAG
 - [ ] Dataset & Experiments
 
 ## Language
+
 - [ ] Python
 - [ ] TypeScript
 
 ## Key Features
+
 - Feature 1
 - Feature 2
 - Feature 3
 
 ## Testing
+
 - [ ] Example runs successfully
 - [ ] README instructions work
 - [ ] Galileo integration tested
 
 ## Screenshots/Demo
+
 (If applicable)
 ```
 
@@ -334,12 +349,14 @@ Brief description of what this example demonstrates.
 ### Agent Examples
 
 Agent examples should demonstrate:
+
 - Tool usage and decision-making
 - Multi-step workflows
 - Error handling and recovery
 - Galileo's agent monitoring features
 
 **Good Examples:**
+
 - Weather agent with multiple tools
 - Financial services agent with document processing
 - Customer support agent with knowledge base
@@ -347,12 +364,14 @@ Agent examples should demonstrate:
 ### Chatbot Examples
 
 Chatbot examples should show:
+
 - Conversation management
 - Context handling
 - Response generation
 - Galileo's conversation tracking
 
 **Good Examples:**
+
 - Simple Q&A chatbot
 - Context-aware conversations
 - Multi-turn dialogue systems
@@ -360,12 +379,14 @@ Chatbot examples should show:
 ### RAG Examples
 
 RAG examples should demonstrate:
+
 - Document retrieval
 - Context augmentation
 - Source attribution
 - Galileo's RAG monitoring
 
 **Good Examples:**
+
 - Document Q&A systems
 - Knowledge base chatbots
 - Research assistants
@@ -373,12 +394,14 @@ RAG examples should demonstrate:
 ### Dataset & Experiment Examples
 
 Dataset examples should show:
+
 - Data management
 - Experiment tracking
 - Evaluation metrics
 - Galileo's dataset features
 
 **Good Examples:**
+
 - A/B testing frameworks
 - Evaluation pipelines
 - Data versioning
@@ -386,12 +409,11 @@ Dataset examples should show:
 ## 🆘 Getting Help
 
 - **Issues**: Use GitHub Issues for bugs or feature requests
-- **Documentation**: Check the [Galileo.ai docs](https://v2docs.galileo.ai/)
-- **Version Control**: use Git for version control and submit a PR when you are ready for review. Tag @jimbobbennett, @erinmikailstaples or @rschwabco for code review. 
-
+- **Documentation**: Check the [Galileo.ai docs](https://docs.galileo.ai/)
+- **Version Control**: use Git for version control and submit a PR when you are ready for review. Tag @jimbobbennett, @erinmikailstaples or @rschwabco for code review.
 
 ---
 
-Thank you for contributing to the Galileo.ai SDK Examples! 
+Thank you for contributing to the Galileo.ai SDK Examples!
 
-Your examples help the community learn and build better AI applications. 🚀 
+Your examples help the community learn and build better AI applications. 🚀

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains example implementations and reference code for using th
 
 ## 🍳 Cookbooks & Tutorials
 
-For comprehensive guides and step-by-step tutorials, check out our **[Galileo Cookbooks](https://v2docs.galileo.ai/cookbooks/overview)** featuring:
+For comprehensive guides and step-by-step tutorials, check out our **[Galileo Cookbooks](https://docs.galileo.ai/cookbooks/overview)** featuring:
 
 - **Agent Development** - Multi-agent systems, LangGraph workflows, and OpenTelemetry integration
 - **RAG Applications** - MongoDB Atlas, Elasticsearch, and vector search implementations
@@ -25,7 +25,7 @@ For comprehensive guides and step-by-step tutorials, check out our **[Galileo Co
 
 When you first sign up for Galileo, you will get 2 sample projects created, a simple chatbot, and a multi-agent banking chatbot. The code for these projects is in this repo.
 
-You can read more about these in our [Get started with sample projects documentation](https://v2docs.galileo.ai/getting-started/sample-projects/sample-projects).
+You can read more about these in our [Get started with sample projects documentation](https://docs.galileo.ai/getting-started/sample-projects/sample-projects).
 
 #### Python
 
@@ -47,8 +47,8 @@ You can read more about these in our [Get started with sample projects documenta
 #### Python Agents 🐍
 
 - **[LangChain Agent](/python/agent/langchain-agent/)** - Basic LangChain agent with Galileo integration
-- **[LangGraph FSI Agent](/python/agent/langgraph-fsi-agent/)** - Financial services agent with before/after implementations  
-- **[LangGraph Telecom Agent](/python/agent/langgraph-telecom-agent/)** - Telecom services agent with Galileo integration  
+- **[LangGraph FSI Agent](/python/agent/langgraph-fsi-agent/)** - Financial services agent with before/after implementations
+- **[LangGraph Telecom Agent](/python/agent/langgraph-telecom-agent/)** - Telecom services agent with Galileo integration
 - **[LangGraph + OpenTelemetry](/python/agent/langgraph-otel/)** - 🎆 **Featured** - Comprehensive observability with OpenTelemetry and Galileo
 - **[CrewAI Agent](/python/agent/crewAI/)** - Multi-agent collaboration using CrewAI framework
 - **[Startup Simulator 3000](/python/agent/startup-simulator-3000/)** - Advanced agent with startup business simulation
@@ -62,7 +62,7 @@ You can read more about these in our [Get started with sample projects documenta
 - **[PydanticAI Support Agent](/python/agent/pydantic-ai-support-agent/)** - Enterprise customer support agent with Galileo observability
 - **[LangChain Agent with Middleware](/python/agent/langchain-middleware/)** - LangChain agent with custom middleware for enhanced functionality
 
-#### TypeScript Agents 📜  
+#### TypeScript Agents 📜
 
 - **[LangGraph FSI Agent](/typescript/agent/langgraph-fsi-agent/)** - Financial services agent in TypeScript
 - **[Stripe Agent Tool](/typescript/agent/stripe-agent-tool/)** - 💳 Agent with Stripe payment processing integration
@@ -83,7 +83,7 @@ You can read more about these in our [Get started with sample projects documenta
 
 #### TypeScript Chatbots 📜
 
-- **[Basic Examples](/typescript/chatbot/basic-examples/)** - Fundamental chatbot patterns in TypeScript  
+- **[Basic Examples](/typescript/chatbot/basic-examples/)** - Fundamental chatbot patterns in TypeScript
 - **[Sample Project Chatbot](/typescript/chatbot/sample-project-chatbot/)** - Multi-LLM chatbot implementations:
   - [OpenAI/Ollama variant](/typescript/chatbot/sample-project-chatbot/openai-ollama/)
   - [Anthropic variant](/typescript/chatbot/sample-project-chatbot/anthropic/)
@@ -121,20 +121,20 @@ You can read more about these in our [Get started with sample projects documenta
 
 #### 📚 Additional Resources
 
-- [Galileo SDK Documentation](https://v2docs.galileo.ai/sdk-api/overview) - SDK documentation
-- [Galileo API Reference](https://v2docs.galileo.ai/api-reference/health/healthcheck) - TypeScript SDK package
-- [Galileo Release Notes](https://v2docs.galileo.ai/release-notes)
+- [Galileo SDK Documentation](https://docs.galileo.ai/sdk-api/overview) - SDK documentation
+- [Galileo API Reference](https://docs.galileo.ai/api-reference/health/healthcheck) - TypeScript SDK package
+- [Galileo Release Notes](https://docs.galileo.ai/release-notes)
 
 ## 📖 Read the Docs
 
 ### Core Documentation
 
-- **[Galileo.ai Documentation](https://v2docs.galileo.ai/what-is-galileo)** - Complete platform overview
-- **[Galileo Cookbooks](https://v2docs.galileo.ai/cookbooks/overview)** - 🔥 **Step-by-step tutorials and guides**
-- **[Python SDK Documentation](https://v2docs.galileo.ai/sdk-api/python/overview)** - Python SDK reference
-- **[TypeScript SDK Documentation](https://v2docs.galileo.ai/sdk-api/typescript/overview)** - TypeScript SDK reference
-- **[API Reference](https://v2docs.galileo.ai/api-reference/health/healthcheck)** - REST API documentation
-- **[Release Notes](https://v2docs.galileo.ai/release-notes)** - Latest updates and features
+- **[Galileo.ai Documentation](https://docs.galileo.ai/what-is-galileo)** - Complete platform overview
+- **[Galileo Cookbooks](https://docs.galileo.ai/cookbooks/overview)** - 🔥 **Step-by-step tutorials and guides**
+- **[Python SDK Documentation](https://docs.galileo.ai/sdk-api/python/overview)** - Python SDK reference
+- **[TypeScript SDK Documentation](https://docs.galileo.ai/sdk-api/typescript/overview)** - TypeScript SDK reference
+- **[API Reference](https://docs.galileo.ai/api-reference/health/healthcheck)** - REST API documentation
+- **[Release Notes](https://docs.galileo.ai/release-notes)** - Latest updates and features
 
 ## 📦 Requirements
 
@@ -146,7 +146,7 @@ You can read more about these in our [Get started with sample projects documenta
 ### 🚀 What You'll Learn
 
 - **Agent Development** - Build AI systems that can use tools, make decisions, and collaborate
-- **Observability** - Comprehensive tracing with OpenTelemetry and Galileo integration  
+- **Observability** - Comprehensive tracing with OpenTelemetry and Galileo integration
 - **RAG Applications** - Combine knowledge bases with LLMs for enhanced responses
 - **Multi-LLM Support** - Work with OpenAI, Anthropic, Azure, and local models like Ollama
 - **Production Patterns** - Error handling, evaluation, and monitoring best practices
@@ -154,9 +154,9 @@ You can read more about these in our [Get started with sample projects documenta
 ### 🎯 Application Patterns Covered
 
 - **🤖 AI Agents** - Tool-using systems with decision-making capabilities
-  - *Featured: LangGraph + OpenTelemetry* - Complete observability setup
-  - *Stripe Agent* - Payment processing integration
-  - *Weather Vibes* - Multi-function agent with external APIs
+  - _Featured: LangGraph + OpenTelemetry_ - Complete observability setup
+  - _Stripe Agent_ - Payment processing integration
+  - _Weather Vibes_ - Multi-function agent with external APIs
 - **💬 Chatbots** - Conversational applications with context management
 - **🔍 RAG Systems** - Knowledge retrieval and generation pipelines
 - **📊 Data & Experiments** - Testing, evaluation, and dataset management
@@ -175,7 +175,7 @@ Each directory contains standalone examples with their own setup instructions an
 ## 🤝 Contributing
 
 Have a great example of how to use Galileo? Or rather — have something you'd like to see how it works with Galileo?
- Please see our [Contributing Guide](CONTRIBUTING.md) for detailed information on how to:
+Please see our [Contributing Guide](CONTRIBUTING.md) for detailed information on how to:
 
 - Open an issue to discuss your idea
 - Add new examples

--- a/ai-evals-course/hw1/README.md
+++ b/ai-evals-course/hw1/README.md
@@ -12,7 +12,7 @@ The original homework assignment has three parts:
 
 ## Using Galileo for this assignment
 
-Galileo has built-in capabilities to perform these tasks, allowing you to create prompts, build datasets or queries, and test and tune the prompts using those dataset. These capabilities are available both in code using [experiments](https://v2docs.galileo.ai/sdk-api/experiments/experiments), or through the Galileo console using [Playgrounds](https://v2docs.galileo.ai/concepts/experiments/running-experiments-in-console).
+Galileo has built-in capabilities to perform these tasks, allowing you to create prompts, build datasets or queries, and test and tune the prompts using those dataset. These capabilities are available both in code using [experiments](https://docs.galileo.ai/sdk-api/experiments/experiments), or through the Galileo console using [Playgrounds](https://docs.galileo.ai/concepts/experiments/running-experiments-in-console).
 
 This folder contains a sample notebook showing all these steps in code.
 

--- a/ai-evals-course/hw1/hw1.ipynb
+++ b/ai-evals-course/hw1/hw1.ipynb
@@ -147,7 +147,7 @@
    "source": [
     "### Create the prompt, and save it to Galileo\n",
     "\n",
-    "You can create [prompts](https://v2docs.galileo.ai/sdk-api/experiments/prompts) in Galileo to run against a dataset of inputs. These prompts use [mustache templates](https://mustache.github.io/), and when run against a dataset, the prompt is run against each row, replacing the templates parts of the prompt with values from the dataset.\n",
+    "You can create [prompts](https://docs.galileo.ai/sdk-api/experiments/prompts) in Galileo to run against a dataset of inputs. These prompts use [mustache templates](https://mustache.github.io/), and when run against a dataset, the prompt is run against each row, replacing the templates parts of the prompt with values from the dataset.\n",
     "\n",
     "Prompts can be created either as global to an organization, so they can be used by any member, or tied to a specific project. In this case, we will create a global prompt so it can be used in different projects for each homework assignment.\n",
     "\n",
@@ -213,7 +213,7 @@
     "\n",
     "There is a [default dataset](https://github.com/ai-evals-course/recipe-chatbot/tree/main/data) provided in the original homework. We can use this to test out the prompt.\n",
     "\n",
-    "Prompts are run against [datasets](https://v2docs.galileo.ai/sdk-api/experiments/datasets) created and maintained in Galileo. This code creates a Galileo dataset.\n",
+    "Prompts are run against [datasets](https://docs.galileo.ai/sdk-api/experiments/datasets) created and maintained in Galileo. This code creates a Galileo dataset.\n",
     "\n",
     "Like with prompts, datasets can be created at an organization or project level. In this case we will create one global to the organization.\n",
     "\n",
@@ -286,7 +286,7 @@
    "source": [
     "### Run the prompt against the dataset using an experiment\n",
     "\n",
-    "Next we can run the prompt using the dataset in an [experiment](https://v2docs.galileo.ai/sdk-api/experiments/experiments). This will use the LLM integration you have set up earlier, and run each dataset row against the LLM using the prompt provided, saving the output to the experiment.\n",
+    "Next we can run the prompt using the dataset in an [experiment](https://docs.galileo.ai/sdk-api/experiments/experiments). This will use the LLM integration you have set up earlier, and run each dataset row against the LLM using the prompt provided, saving the output to the experiment.\n",
     "\n",
     "Experiments need a unique name, but if a name is in use then the current date and time is added. This means you can re-run this code and always get a new experiment.\n",
     "\n",
@@ -533,7 +533,7 @@
     "\n",
     "The final step asks you to run the bulk test script. This script takes the dataset, uses the system prompt you defined earlier, then runs each row from the sample queries against that prompt, outputting the results.\n",
     "\n",
-    "We can do this in a more consistent fashion by running our experiment again with the new dataset. That way the results persist, and we can [compare the experiment runs](https://v2docs.galileo.ai/concepts/experiments/compare) to see the impact of system prompt changes.\n",
+    "We can do this in a more consistent fashion by running our experiment again with the new dataset. That way the results persist, and we can [compare the experiment runs](https://docs.galileo.ai/concepts/experiments/compare) to see the impact of system prompt changes.\n",
     "\n",
     "Once the experiment is started, you will see a link in the output to monitor the progress and see the results."
    ]
@@ -566,7 +566,7 @@
     "- Add a unit test to the recipe chatbot. This unit test uses the `run_experiment` call, but instead of passing in a prompt, it passes in a function. This function is the call to the recipe agent, calling the [`get_agent_response` function](https://github.com/ai-evals-course/recipe-chatbot/blob/35618065f209dbf27075b4a4183a986a0c10bd14/backend/utils.py#L31). You would probably need a wrapper function to ensure the dataset row and system prompt are passed in to this function correctly.\n",
     "- Add Galileo logging where applicable inside the app to gather as much detail for the experiment trace as possible.\n",
     "\n",
-    "You can read more about running functions as experiments in the [Galileo experiments documentation](https://v2docs.galileo.ai/sdk-api/experiments/running-experiments#run-experiments-against-complex-code-with-custom-functions)."
+    "You can read more about running functions as experiments in the [Galileo experiments documentation](https://docs.galileo.ai/sdk-api/experiments/running-experiments#run-experiments-against-complex-code-with-custom-functions)."
    ]
   }
  ],

--- a/ai-evals-course/hw3/hw3.ipynb
+++ b/ai-evals-course/hw3/hw3.ipynb
@@ -318,9 +318,9 @@
     "\n",
     "For the expected output, the metric should return `true` if the output follows the dietary restrictions defined in the input, otherwise return `false`. You also do not need to ask for reasoning, this is handled automatically by Galileo.\n",
     "\n",
-    "This prompt will be used by Galileo to evaluate the outputs. Refer to the [LLM-as-a-judge prompt engineering guide in the Galileo documentation](https://v2docs.galileo.ai/concepts/metrics/custom-metrics/prompt-engineering) for more guidance on how to structure a good LLM-as-a-judge prompt.\n",
+    "This prompt will be used by Galileo to evaluate the outputs. Refer to the [LLM-as-a-judge prompt engineering guide in the Galileo documentation](https://docs.galileo.ai/concepts/metrics/custom-metrics/prompt-engineering) for more guidance on how to structure a good LLM-as-a-judge prompt.\n",
     "\n",
-    "> Instead of creating this metric in code, you can also create and test it in the Galileo console, including using Prompt Assist to get the prompt created for you. You can read more in the [Galileo custom LLM-as-a-judge metrics documentation](https://v2docs.galileo.ai/concepts/metrics/custom-metrics/custom-metrics-ui-llm#create-a-new-llm-as-a-judge-metric-in-the-galileo-console)."
+    "> Instead of creating this metric in code, you can also create and test it in the Galileo console, including using Prompt Assist to get the prompt created for you. You can read more in the [Galileo custom LLM-as-a-judge metrics documentation](https://docs.galileo.ai/concepts/metrics/custom-metrics/custom-metrics-ui-llm#create-a-new-llm-as-a-judge-metric-in-the-galileo-console)."
    ]
   },
   {

--- a/ai-evals-course/hw4/hw4.ipynb
+++ b/ai-evals-course/hw4/hw4.ipynb
@@ -407,7 +407,7 @@
     "\n",
     "We can now evaluate the retrieval using a metric. In this case, we can use a code-based metric, instead of an LLM-as-a-judge metric, as we have access to a ground truth to look up how successful the retrieval was.\n",
     "\n",
-    "We can do this using a [local metric](https://v2docs.galileo.ai/concepts/metrics/custom-metrics/custom-metrics-ui-code#local-metrics). This is a metric we can use in an experiment that runs locally. This makes our metric simpler. You can take the local metric and upload it to Galileo later if needed.\n",
+    "We can do this using a [local metric](https://docs.galileo.ai/concepts/metrics/custom-metrics/custom-metrics-ui-code#local-metrics). This is a metric we can use in an experiment that runs locally. This makes our metric simpler. You can take the local metric and upload it to Galileo later if needed.\n",
     "\n",
     "For this example, we'll just measure the mean reciprocal rank, but you can use the same idea to measure the different Recall@k values."
    ]

--- a/python/agent/crewAI/README.md
+++ b/python/agent/crewAI/README.md
@@ -5,9 +5,9 @@ This repo contains examples of how to use Galileo to instrument [CrewAI](https:/
 ## research_crew
 
 The [resarch-crew](./research_crew/) is a quickstart tutorial. It is a completed version of the [CrewAI quickstart](https://docs.crewai.com/en/quickstart) and adds the
-Galileo's [CrewAIEventListener](https://v2docs.galileo.ai/sdk-api/python/reference/handlers/crewai/handler),
+Galileo's [CrewAIEventListener](https://docs.galileo.ai/sdk-api/python/reference/handlers/crewai/handler),
 an event handler implemented on top of OpenTelemetry (OTel). For more information, see
-Galileo’s [Add Galileo to a CrewAI Application](https://v2docs.galileo.ai/how-to-guides/third-party-integrations/add-galileo-to-crewai/add-galileo-to-crewai)
+Galileo’s [Add Galileo to a CrewAI Application](https://docs.galileo.ai/how-to-guides/third-party-integrations/add-galileo-to-crewai/add-galileo-to-crewai)
 how-to guide.
 
 See the [README.md](./research_crew/README.md) for detailed setup instructions.

--- a/python/agent/crewAI/research_crew/README.md
+++ b/python/agent/crewAI/research_crew/README.md
@@ -1,9 +1,9 @@
 # CrewAI and Galileo Cookbook
 
 This tutorial is a completed version of the [CrewAI quickstart](https://docs.crewai.com/en/quickstart) and adds the
-Galileo [CrewAIEventListener](https://v2docs.galileo.ai/sdk-api/python/reference/handlers/crewai/handler),
+Galileo [CrewAIEventListener](https://docs.galileo.ai/sdk-api/python/reference/handlers/crewai/handler),
 an event handler implemented on top of OpenTelemetry (OTel). For more information, see
-Galileo’s [Add Galileo to a CrewAI Application](https://v2docs.galileo.ai/how-to-guides/third-party-integrations/add-galileo-to-crewai/add-galileo-to-crewai)
+Galileo’s [Add Galileo to a CrewAI Application](https://docs.galileo.ai/how-to-guides/third-party-integrations/add-galileo-to-crewai/add-galileo-to-crewai)
 how-to guide.
 
 Below you'll find concise setup steps, configuration notes, and a short primer on Galileo so you know why we add it and what it provides.
@@ -12,7 +12,7 @@ Below you'll find concise setup steps, configuration notes, and a short primer o
 
 The relevant guides:
 
-- [Add Galileo to CrewAI](https://v2docs.galileo.ai/how-to-guides/third-party-integrations/add-galileo-to-crewai/add-galileo-to-crewai)
+- [Add Galileo to CrewAI](https://docs.galileo.ai/how-to-guides/third-party-integrations/add-galileo-to-crewai/add-galileo-to-crewai)
 - [CrewAI quickstart](https://docs.crewai.com/en/guides/crews/first-crew)
 
 ## What is Galileo?

--- a/python/agent/google-adk/README.md
+++ b/python/agent/google-adk/README.md
@@ -28,7 +28,7 @@ GALILEO_LOG_STREAM=
 
 For the `GALILEO_API_ENDPOINT`, this is different to the console URL that you would normally use. If you are using `app.galileo.ai` for example, the endpoint is `https://api.galileo.ai/otel/traces`.
 
-See the [Galileo OTel and OpenInference documentation](https://v2docs.galileo.ai/sdk-api/third-party-integrations/opentelemetry-and-openinference) for more details.
+See the [Galileo OTel and OpenInference documentation](https://docs.galileo.ai/sdk-api/third-party-integrations/opentelemetry-and-openinference) for more details.
 
 ## Usage
 

--- a/python/agent/langchain-middleware/README.md
+++ b/python/agent/langchain-middleware/README.md
@@ -54,10 +54,10 @@ The middleware creates a hierarchical trace with:
 
 ## Comparison with Callbacks
 
-| Feature | GalileoMiddleware | GalileoCallback |
-|---------|------------------|-----------------|
-| Setup | Add to middleware list | Pass to each component |
-| Complexity | Simple | Manual setup required |
-| Best for | LangGraph agents | Complex LangChain apps |
+| Feature    | GalileoMiddleware      | GalileoCallback        |
+| ---------- | ---------------------- | ---------------------- |
+| Setup      | Add to middleware list | Pass to each component |
+| Complexity | Simple                 | Manual setup required  |
+| Best for   | LangGraph agents       | Complex LangChain apps |
 
-For more details, see the [middleware documentation](https://v2docs.galileo.ai/sdk-api/third-party-integrations/langchain/middleware).
+For more details, see the [middleware documentation](https://docs.galileo.ai/sdk-api/third-party-integrations/langchain/middleware).

--- a/python/agent/langgraph-fsi-agent/README.md
+++ b/python/agent/langgraph-fsi-agent/README.md
@@ -9,7 +9,7 @@ In this folder you will find 2 versions of the app:
 - A [before version](./before/) that contains the app without any evaluations
 - An [after version](./after/) that contains the app with evaluations
 
-To learn how to add evaluations, check out the [Add evaluations to a multi-agent LangGraph application cookbook](https://v2docs.galileo.ai/cookbooks/use-cases/multi-agent-langgraph/multi-agent-langgraph) in the Galileo documentation.
+To learn how to add evaluations, check out the [Add evaluations to a multi-agent LangGraph application cookbook](https://docs.galileo.ai/cookbooks/use-cases/multi-agent-langgraph/multi-agent-langgraph) in the Galileo documentation.
 
 ## Overview of this app
 
@@ -124,7 +124,7 @@ To run the app, you need the following:
 1. Copy the `.env.example` file to `.env`
 1. Fill in the values
 
-    For the Galileo values, you MUST create the project up front, but the log stream does not need to be created, it will be created automatically
+   For the Galileo values, you MUST create the project up front, but the log stream does not need to be created, it will be created automatically
 
 ### Install the dependencies
 
@@ -172,7 +172,7 @@ From there you can configure the metrics you are interested in. Once metrics are
 
 This project also includes a unit test to run the chatbot with a set of defined prompts, evaluating the prompts for action advancement, action completion, tool selection quality, and tool errors, only passing the test if both metrics score an average of 100% (or 0% for tool errors) over all the entries in the dataset.
 
-This is run using the [Galileo experiments framework](https://v2docs.galileo.ai/concepts/experiments/overview) - allowing you to run any code as an experiment against a fixed dataset of prompts. This mechanism allows you to run AI applications, from simple to complex, under test conditions with a defined set of inputs. You can then use the results of evaluations run against your app to help with model selection or prompt engineering, as well as validating your application as part of a CI/CD pipeline.
+This is run using the [Galileo experiments framework](https://docs.galileo.ai/concepts/experiments/overview) - allowing you to run any code as an experiment against a fixed dataset of prompts. This mechanism allows you to run AI applications, from simple to complex, under test conditions with a defined set of inputs. You can then use the results of evaluations run against your app to help with model selection or prompt engineering, as well as validating your application as part of a CI/CD pipeline.
 
 You can run the unit test by running the following command inside your virtual environment:
 

--- a/python/agent/langgraph-open-telemetry/README.md
+++ b/python/agent/langgraph-open-telemetry/README.md
@@ -6,7 +6,7 @@ This example demonstrates how to add comprehensive observability to your LangGra
 
 **OpenTelemetry** is an observability framework that creates traces showing what functions ran, their timing, and data flow through your application. The **OpenTelemetry instrumentation libraries** automatically instrument AI frameworks like LangChain and OpenAI. **Galileo** provides a sophisticated platform for visualizing and analyzing your AI application traces.
 
-For detailed explanations and advanced patterns, see the [LangGraph OpenTelemetry cookbook](https://v2docs.galileo.ai/cookbooks/features/integrations/langgraph-otel-cookbook)
+For detailed explanations and advanced patterns, see the [LangGraph OpenTelemetry cookbook](https://docs.galileo.ai/cookbooks/features/integrations/langgraph-otel-cookbook)
 
 ## Quick start
 
@@ -53,12 +53,12 @@ GALILEO_CONSOLE_URL=https://app.galileo.ai
 OPENAI_API_KEY=your_openai_api_key_here
 ```
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `GALILEO_API_KEY` | Yes | Your Galileo API key from [settings](https://app.galileo.ai/settings/api-keys) |
-| `GALILEO_PROJECT` | Yes | Galileo project name (create one in your dashboard) |
-| `GALILEO_LOGSTREAM` | Yes | Log stream name for organizing traces (default: "default") |
-| `OPENAI_API_KEY` | Yes | Your OpenAI API key from [OpenAI](https://platform.openai.com/api-keys) |
+| Variable            | Required | Description                                                                    |
+| ------------------- | -------- | ------------------------------------------------------------------------------ |
+| `GALILEO_API_KEY`   | Yes      | Your Galileo API key from [settings](https://app.galileo.ai/settings/api-keys) |
+| `GALILEO_PROJECT`   | Yes      | Galileo project name (create one in your dashboard)                            |
+| `GALILEO_LOGSTREAM` | Yes      | Log stream name for organizing traces (default: "default")                     |
+| `OPENAI_API_KEY`    | Yes      | Your OpenAI API key from [OpenAI](https://platform.openai.com/api-keys)        |
 
 ### Run
 
@@ -77,8 +77,8 @@ This runs a question-answering LangGraph workflow with comprehensive OpenTelemet
 
 ## Learn more
 
-- [LangGraph OpenTelemetry cookbook](https://v2docs.galileo.ai/cookbooks/features/integrations/langgraph-otel-cookbook)
+- [LangGraph OpenTelemetry cookbook](https://docs.galileo.ai/cookbooks/features/integrations/langgraph-otel-cookbook)
 - [LangGraph Documentation](https://langchain-ai.github.io/langgraph/)
 - [OpenTelemetry Python](https://opentelemetry.io/docs/instrumentation/python/)
-- [Galileo Documentation](https://v2docs.galileo.ai/)
+- [Galileo Documentation](https://docs.galileo.ai/)
 - [UV Package Manager](https://docs.astral.sh/uv/)

--- a/python/agent/langgraph-otel/README.md
+++ b/python/agent/langgraph-otel/README.md
@@ -6,17 +6,19 @@ This example demonstrates how to add comprehensive observability to your LangGra
 
 **OpenTelemetry** is an observability framework that creates traces showing what functions ran, their timing, and data flow through your application. **OpenInference** automatically instruments AI frameworks like LangChain and OpenAI. **Galileo** provides a sophisticated platform for visualizing and analyzing your AI application traces.
 
-For detailed explanations and advanced patterns, see the [LangGraph OpenTelemetry cookbook](https://v2docs.galileo.ai/cookbooks/features/integrations/langgraph-otel-cookbook)
+For detailed explanations and advanced patterns, see the [LangGraph OpenTelemetry cookbook](https://docs.galileo.ai/cookbooks/features/integrations/langgraph-otel-cookbook)
 
 ## Quick start
 
 ### Prerequisites
+
 - Python 3.10+
 - [UV package manager](https://docs.astral.sh/uv/getting-started/installation/)
 - [Galileo account](https://app.galileo.ai) (free)
 - OpenAI API key
 
 ### Installation
+
 ```bash
 # Clone and navigate
 git clone https://github.com/rungalileo/sdk-examples
@@ -51,14 +53,15 @@ GALILEO_CONSOLE_URL=https://app.galileo.ai
 OPENAI_API_KEY=your_openai_api_key_here
 ```
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `GALILEO_API_KEY` | Yes | Your Galileo API key from [settings](https://app.galileo.ai/settings/api-keys) |
-| `GALILEO_PROJECT` | Yes | Galileo project name (create one in your dashboard) |
-| `GALILEO_LOG_STREAM` | Yes | Log stream name for organizing traces (default: "default") |
-| `OPENAI_API_KEY` | Yes | Your OpenAI API key from [OpenAI](https://platform.openai.com/api-keys) |
+| Variable             | Required | Description                                                                    |
+| -------------------- | -------- | ------------------------------------------------------------------------------ |
+| `GALILEO_API_KEY`    | Yes      | Your Galileo API key from [settings](https://app.galileo.ai/settings/api-keys) |
+| `GALILEO_PROJECT`    | Yes      | Galileo project name (create one in your dashboard)                            |
+| `GALILEO_LOG_STREAM` | Yes      | Log stream name for organizing traces (default: "default")                     |
+| `OPENAI_API_KEY`     | Yes      | Your OpenAI API key from [OpenAI](https://platform.openai.com/api-keys)        |
 
 ### Run
+
 ```bash
 uv run python main.py
 ```
@@ -91,7 +94,7 @@ In Galileo, you'll see a clean trace structure:
 
 ### Key Observability Benefits
 
-- **Complete Input/Output Visibility** - See data flowing through each step  
+- **Complete Input/Output Visibility** - See data flowing through each step
 - **LLM Call Details** - Token usage, model parameters, and timing
 - **Session Context** - Grouped operations with meaningful metadata
 - **Error Tracking** - Automatic error capture and status tracking
@@ -114,8 +117,8 @@ Each span includes rich metadata:
 
 ## Learn more
 
-- [LangGraph OpenTelemetry cookbook](https://v2docs.galileo.ai/cookbooks/features/integrations/langgraph-otel-cookbook) 
+- [LangGraph OpenTelemetry cookbook](https://docs.galileo.ai/cookbooks/features/integrations/langgraph-otel-cookbook)
 - [LangGraph Documentation](https://langchain-ai.github.io/langgraph/)
 - [OpenTelemetry Python](https://opentelemetry.io/docs/instrumentation/python/)
-- [Galileo Documentation](https://v2docs.galileo.ai/)
+- [Galileo Documentation](https://docs.galileo.ai/)
 - [UV Package Manager](https://docs.astral.sh/uv/)

--- a/python/agent/microsoft-agent-framework/README.md
+++ b/python/agent/microsoft-agent-framework/README.md
@@ -25,7 +25,7 @@ GALILEO_PROJECT=
 GALILEO_LOG_STREAM=
 ```
 
-For the `GALILEO_API_ENDPOINT`, you only need to set this if you are using a custom Galileo deployment. There is no need to set this if you are using [app.galileo.ai](https://app.galileo.ai). This endpoint is different to the console URL that you would normally use. See the [Galileo OpenTelemetry documentation](https://v2docs.galileo.ai/sdk-api/third-party-integrations/opentelemetry-and-openinference#self-hosted-deployments) for more details.
+For the `GALILEO_API_ENDPOINT`, you only need to set this if you are using a custom Galileo deployment. There is no need to set this if you are using [app.galileo.ai](https://app.galileo.ai). This endpoint is different to the console URL that you would normally use. See the [Galileo OpenTelemetry documentation](https://docs.galileo.ai/sdk-api/third-party-integrations/opentelemetry-and-openinference#self-hosted-deployments) for more details.
 
 ## Usage
 

--- a/python/agent/strands-agents/README.md
+++ b/python/agent/strands-agents/README.md
@@ -25,7 +25,7 @@ GALILEO_PROJECT=
 GALILEO_LOG_STREAM=
 ```
 
-For the `GALILEO_API_ENDPOINT`, you only need to set this if you are using a custom Galileo deployment. There is no need to set this if you ae using [app.galileo.ai](https://app.galileo.ai). This endpoint is different to the console URL that you would normally use. See the [Galileo OpenTelemetry documentation](https://v2docs.galileo.ai/sdk-api/third-party-integrations/opentelemetry-and-openinference#self-hosted-deployments) for more details.
+For the `GALILEO_API_ENDPOINT`, you only need to set this if you are using a custom Galileo deployment. There is no need to set this if you ae using [app.galileo.ai](https://app.galileo.ai). This endpoint is different to the console URL that you would normally use. See the [Galileo OpenTelemetry documentation](https://docs.galileo.ai/sdk-api/third-party-integrations/opentelemetry-and-openinference#self-hosted-deployments) for more details.
 
 ## Usage
 

--- a/python/agent/weather-vibes-agent/00-tutorial/03-using-galileo.md
+++ b/python/agent/weather-vibes-agent/00-tutorial/03-using-galileo.md
@@ -1,8 +1,11 @@
 # Using Galileo with Weather Vibes Agent
+
 This document explains how to use Galileo for evaluating and monitoring the Weather Vibes agent.
 
 ## What is Galileo?
+
 [Galileo](https://www.rungalileo.io/) is an AI observability and evaluation platform that helps you:
+
 - Track agent behavior
 - Collect and analyze traces
 - Evaluate agent performance
@@ -10,6 +13,7 @@ This document explains how to use Galileo for evaluating and monitoring the Weat
 - Monitor production deployments
 
 ## Setup
+
 ### 1. Install Galileo SDK
 
 ```bash
@@ -33,6 +37,7 @@ GALILEO_LOG_STREAM=your-galileo-log-stream       # The name of the log stream yo
 You can get your API key from the Galileo dashboard.
 
 ## Running the Galileo-Instrumented Agent
+
 Run the agent with Galileo instrumentation:
 
 ```bash
@@ -46,7 +51,8 @@ python galileo_agent.py --location "Tokyo" --units imperial --mood relaxing --ve
 ```
 
 ## Understanding the Spans
-The Galileo-instrumented version of the agent includes several span types.  Learn more about spans, the atomic unit of logging in Galileo, [here](https://v2docs.galileo.ai/getting-started/logging).
+
+The Galileo-instrumented version of the agent includes several span types. Learn more about spans, the atomic unit of logging in Galileo, [here](https://docs.galileo.ai/getting-started/logging).
 
 1. **Workflow Span** (`workflow`):
    - Captures the main agent workflow in `process_request`
@@ -68,20 +74,26 @@ The Galileo-instrumented version of the agent includes several span types.  Lear
    - Currently not used in this agent but available for future retrieval operations
 
 ## Viewing Traces in Galileo
+
 After running the agent, you can view the traces in the Galileo dashboard. The traces will show:
+
 - Request and response data for each span
 - Execution time for each component
 - Hierarchical view of the agent's workflow
 - Input/output data flow between components
 
 ## Customizing Instrumentation
+
 You can add more spans or customize existing ones by modifying `agent.py`:
+
 1. **Adding LLM spans**: If you implement LLM-based tools, use `@log(span_type="llm")` decorators
 2. **Adding retrieval spans**: For document retrieval functions, use `@log(span_type="retriever")` decorators
 3. **Custom span names**: Modify the `name` parameter in decorators for better organization
 
 ## Using Galileo for Evaluation
+
 You can use Galileo's evaluation features to:
+
 1. **Create eval datasets**: Build a set of test inputs for your agent
 2. **Define metrics**: Set up metrics to measure agent performance
 3. **Run evaluations**: Test your agent against the datasets
@@ -89,10 +101,12 @@ You can use Galileo's evaluation features to:
 5. **Improve the agent**: Make targeted improvements based on insights
 
 ## Troubleshooting
+
 If you encounter issues with Galileo:
+
 - Check that your API key is correctly set in the environment
 - Ensure the Galileo SDK is properly installed
 - Verify that your spans are correctly configured
 - Check the Galileo documentation for more information
 
-For more information, visit the [Galileo documentation](https://v2docs.galileo.ai/what-is-galileo). 
+For more information, visit the [Galileo documentation](https://docs.galileo.ai/what-is-galileo).

--- a/python/chatbot/elevenlabs-chatbot/README.md
+++ b/python/chatbot/elevenlabs-chatbot/README.md
@@ -14,28 +14,33 @@ A terminal-based voice chatbot that lets you have real-time voice conversations 
 ## Quick Start
 
 1. Install system dependencies (macOS):
+
    ```bash
    brew install portaudio
    ```
 
 2. Create and activate a virtual environment:
+
    ```bash
    python -m venv venv
    source venv/bin/activate  # On Windows: venv\Scripts\activate
    ```
 
 3. Install Python dependencies:
+
    ```bash
    pip install -r requirements.txt
    ```
 
 4. Set up environment variables:
+
    ```bash
    cp .env.example .env
    # Edit .env with your API keys
    ```
 
 5. Run the voice chat:
+
    ```bash
    python main.py
    ```
@@ -46,22 +51,21 @@ A terminal-based voice chatbot that lets you have real-time voice conversations 
 
 Edit `.env` with your credentials. Note for `ELEVENLABS_*` variables you can [signup with a free tier](https://elevenlabs.io/app/sign-up?platform=agents) of ElevenLabs and use their Agents Platform to create a voice agent to obtain the required API key and Agent Id:
 
-| Variable | Description |
-|----------|-------------|
-| `ELEVENLABS_API_KEY` | Your ElevenLabs API key |
-| `ELEVENLABS_AGENT_ID` | Your ElevenLabs Agent ID |
-| `GALILEO_API_KEY` | Your Galileo API key |
-| `GALILEO_CONSOLE_URL` | Galileo console URL (optional) |
-| `GALILEO_PROJECT_NAME` | Project name for logging |
+| Variable               | Description                    |
+| ---------------------- | ------------------------------ |
+| `ELEVENLABS_API_KEY`   | Your ElevenLabs API key        |
+| `ELEVENLABS_AGENT_ID`  | Your ElevenLabs Agent ID       |
+| `GALILEO_API_KEY`      | Your Galileo API key           |
+| `GALILEO_CONSOLE_URL`  | Galileo console URL (optional) |
+| `GALILEO_PROJECT_NAME` | Project name for logging       |
 
 ## Requirements
 
 - Python 3.10+
 - Microphone and headphones (to avoid audio feedback)
 
-
 ## Learn More
 
 - [Video tutorial](https://youtu.be/1QNEhDV2r5U)
-- [Galileo Documentation](https://v2docs.galileo.ai/what-is-galileo)
+- [Galileo Documentation](https://docs.galileo.ai/what-is-galileo)
 - [ElevenLabs Conversational AI](https://elevenlabs.io/docs/conversational-ai)

--- a/python/chatbot/sample-project-chatbot/anthropic/README.md
+++ b/python/chatbot/sample-project-chatbot/anthropic/README.md
@@ -24,28 +24,25 @@ To set up this project:
 
 1. Install the required Python dependencies in a virtual environment from the requirements.txt file:
 
-    ```bash
-    pip install -r requirements.txt
-    ```
+   ```bash
+   pip install -r requirements.txt
+   ```
 
 ### Set up the environment
 
 1. Create a `.env` file by copying the `.env.example` file.
 
 1. Fill in the required values for the Galileo environment variables in the `.env` file:
+   - `GALILEO_API_KEY` - Set this to your Galileo API key
+   - `GALILEO_PROJECT` - Set this to your Galileo Project name
+   - `GALILEO_LOG_STREAM` - Set this to your Galileo Log stream name
 
-    - `GALILEO_API_KEY` - Set this to your Galileo API key
-    - `GALILEO_PROJECT` - Set this to your Galileo Project name
-    - `GALILEO_LOG_STREAM` - Set this to your Galileo Log stream name
-
-    There are also some optional values:
-
-    - `GALILEO_CONSOLE_URL` - If you are using a hosted version of Galileo, set the console URL here. For the free version, remove or comment out this value
+   There are also some optional values:
+   - `GALILEO_CONSOLE_URL` - If you are using a hosted version of Galileo, set the console URL here. For the free version, remove or comment out this value
 
 1. Fill in the required values for your LLM in the `.env` file:
-
-    - Set `ANTHROPIC_API_KEY` to your Anthropic API key
-    - Set `MODEL_NAME` to the name of the model you want to use.
+   - Set `ANTHROPIC_API_KEY` to your Anthropic API key
+   - Set `MODEL_NAME` to the name of the model you want to use.
 
 ## Run the chatbot
 
@@ -73,7 +70,7 @@ These moons are significant for their unique geological features and potential f
 
 Every run of the app is logged as a new session in Galileo, with each prompt and response a separate trace.
 
-To evaluate the chatbot, head to your project and Log stream in the Galileo console. Turn on [instruction adherence](https://v2docs.galileo.ai/concepts/metrics/response-quality/instruction-adherence) and [correctness](https://v2docs.galileo.ai/concepts/metrics/response-quality/correctness) for your Log stream.
+To evaluate the chatbot, head to your project and Log stream in the Galileo console. Turn on [instruction adherence](https://docs.galileo.ai/concepts/metrics/response-quality/instruction-adherence) and [correctness](https://docs.galileo.ai/concepts/metrics/response-quality/correctness) for your Log stream.
 
 Then when you run the chatbot, these metrics will be evaluated.
 

--- a/python/chatbot/sample-project-chatbot/azure-inference/README.md
+++ b/python/chatbot/sample-project-chatbot/azure-inference/README.md
@@ -24,29 +24,26 @@ To set up this project:
 
 1. Install the required Python dependencies in a virtual environment from the requirements.txt file:
 
-    ```bash
-    pip install -r requirements.txt
-    ```
+   ```bash
+   pip install -r requirements.txt
+   ```
 
 ### Set up the environment
 
 1. Create a `.env` file by copying the `.env.example` file.
 
 1. Fill in the required values for the Galileo environment variables in the `.env` file:
+   - `GALILEO_API_KEY` - Set this to your Galileo API key
+   - `GALILEO_PROJECT` - Set this to your Galileo Project name
+   - `GALILEO_LOG_STREAM` - Set this to your Galileo Log stream name
 
-    - `GALILEO_API_KEY` - Set this to your Galileo API key
-    - `GALILEO_PROJECT` - Set this to your Galileo Project name
-    - `GALILEO_LOG_STREAM` - Set this to your Galileo Log stream name
-
-    There are also some optional values:
-
-    - `GALILEO_CONSOLE_URL` - If you are using a hosted version of Galileo, set the console URL here. For the free version, remove or comment out this value
+   There are also some optional values:
+   - `GALILEO_CONSOLE_URL` - If you are using a hosted version of Galileo, set the console URL here. For the free version, remove or comment out this value
 
 1. Fill in the required values for your LLM in the `.env` file:
-
-    - Set `AZURE_AI_INFERENCE_ENDPOINT` to your endpoint from AI Foundry
-    - Set `AZURE_AI_INFERENCE_API_KEY` to your API key
-    - Set `MODEL_NAME` to the name of the model deployment you want to use.
+   - Set `AZURE_AI_INFERENCE_ENDPOINT` to your endpoint from AI Foundry
+   - Set `AZURE_AI_INFERENCE_API_KEY` to your API key
+   - Set `MODEL_NAME` to the name of the model deployment you want to use.
 
 ## Run the chatbot
 
@@ -74,7 +71,7 @@ These moons are significant for their unique geological features and potential f
 
 Every run of the app is logged as a new session in Galileo, with each prompt and response a separate trace.
 
-To evaluate the chatbot, head to your project and Log stream in the Galileo console. Turn on [instruction adherence](https://v2docs.galileo.ai/concepts/metrics/response-quality/instruction-adherence) and [correctness](https://v2docs.galileo.ai/concepts/metrics/response-quality/correctness) for your Log stream.
+To evaluate the chatbot, head to your project and Log stream in the Galileo console. Turn on [instruction adherence](https://docs.galileo.ai/concepts/metrics/response-quality/instruction-adherence) and [correctness](https://docs.galileo.ai/concepts/metrics/response-quality/correctness) for your Log stream.
 
 Then when you run the chatbot, these metrics will be evaluated.
 

--- a/python/chatbot/sample-project-chatbot/openai-ollama/README.md
+++ b/python/chatbot/sample-project-chatbot/openai-ollama/README.md
@@ -24,30 +24,27 @@ To set up this project:
 
 1. Install the required Python dependencies in a virtual environment from the requirements.txt file:
 
-    ```bash
-    pip install -r requirements.txt
-    ```
+   ```bash
+   pip install -r requirements.txt
+   ```
 
 ### Set up the environment
 
 1. Create a `.env` file by copying the `.env.example` file.
 
 1. Fill in the required values for the Galileo environment variables in the `.env` file:
+   - `GALILEO_API_KEY` - Set this to your Galileo API key
+   - `GALILEO_PROJECT` - Set this to your Galileo Project name
+   - `GALILEO_LOG_STREAM` - Set this to your Galileo Log stream name
 
-    - `GALILEO_API_KEY` - Set this to your Galileo API key
-    - `GALILEO_PROJECT` - Set this to your Galileo Project name
-    - `GALILEO_LOG_STREAM` - Set this to your Galileo Log stream name
-
-    There are also some optional values:
-
-    - `GALILEO_CONSOLE_URL` - If you are using a hosted version of Galileo, set the console URL here. For the free version, remove or comment out this value
+   There are also some optional values:
+   - `GALILEO_CONSOLE_URL` - If you are using a hosted version of Galileo, set the console URL here. For the free version, remove or comment out this value
 
 1. Fill in the required values for your LLM in the `.env` file:
-
-    - For OpenAI or other compatible API, set `OPENAI_API_KEY` to your API key.
-    - If you are using a custom OpenAI API deployment or compatible API, set `OPENAI_BASE_URL` to the relevant URL.
-    - For Ollama, set `OPENAI_API_KEY` to `ollama`, set `OPENAI_BASE_URL` to `http://localhost:11434/v1`
-    - Set the `MODEL_NAME` to the name of the model you want to use.
+   - For OpenAI or other compatible API, set `OPENAI_API_KEY` to your API key.
+   - If you are using a custom OpenAI API deployment or compatible API, set `OPENAI_BASE_URL` to the relevant URL.
+   - For Ollama, set `OPENAI_API_KEY` to `ollama`, set `OPENAI_BASE_URL` to `http://localhost:11434/v1`
+   - Set the `MODEL_NAME` to the name of the model you want to use.
 
 ## Run the chatbot
 
@@ -75,7 +72,7 @@ These moons are significant for their unique geological features and potential f
 
 Every run of the app is logged as a new session in Galileo, with each prompt and response a separate trace.
 
-To evaluate the chatbot, head to your project and Log stream in the Galileo console. Turn on [instruction adherence](https://v2docs.galileo.ai/concepts/metrics/response-quality/instruction-adherence) and [correctness](https://v2docs.galileo.ai/concepts/metrics/response-quality/correctness) for your Log stream.
+To evaluate the chatbot, head to your project and Log stream in the Galileo console. Turn on [instruction adherence](https://docs.galileo.ai/concepts/metrics/response-quality/instruction-adherence) and [correctness](https://docs.galileo.ai/concepts/metrics/response-quality/correctness) for your Log stream.
 
 Then when you run the chatbot, these metrics will be evaluated.
 

--- a/python/experiments/rag-and-tools/README.md
+++ b/python/experiments/rag-and-tools/README.md
@@ -2,7 +2,7 @@
 
 This is an example project demonstrating how to use Galileo experiments with applications that use RAG and tools.
 
-This code is used in the [Run an experiment against a RAG app](http://v2docs.galileo.ai/how-to-guides/experiments/rag-app/rag-app) how-to guide in the Galileo documentation.
+This code is used in the [Run an experiment against a RAG app](http://docs.galileo.ai/how-to-guides/experiments/rag-app/rag-app) how-to guide in the Galileo documentation.
 
 ## Get Started
 

--- a/python/experiments/upload_experiment/README.md
+++ b/python/experiments/upload_experiment/README.md
@@ -11,6 +11,7 @@ Sometimes you've already run evaluations—whether with a different tool, offlin
 - ✅ Compute Galileo metrics on existing results
 
 This is particularly useful when:
+
 - You have legacy evaluation data to migrate to Galileo
 - You ran evaluations with custom tooling and want unified visualization
 - You need to analyze past model behavior with Galileo's evaluation metrics
@@ -22,6 +23,7 @@ This is particularly useful when:
 **The Solution:** This example takes your pre-existing evaluation data (questions, contexts, LLM responses, ground truth) and uploads it to Galileo as a completed experiment with full tracing.
 
 **How it Works:**
+
 1. Your JSON file contains complete evaluation records (question, context chunks array, LLM answer, ground truth)
 2. A Galileo dataset is created with inputs and expected outputs
 3. An experiment "replays" your results, reconstructing execution traces with proper chunk attribution
@@ -35,20 +37,22 @@ Your evaluation data should be in JSON format with the following structure:
 [
   {
     "question": "Your input/question text",
-    "context": ["chunk1", "chunk2", "chunk3"],  // Array of context chunks
+    "context": ["chunk1", "chunk2", "chunk3"], // Array of context chunks
     "llm_answer": "The response your model generated",
     "ground_truth_answer": "The expected correct answer",
-    "model": "gpt-4o"  // Optional: specify the model used
+    "model": "gpt-4o" // Optional: specify the model used
   }
 ]
 ```
 
 **Required fields:**
+
 - `question` - The input to your system
 - `llm_answer` - The response your system generated
 - `ground_truth_answer` - The expected/correct answer
 
 **Optional fields:**
+
 - `context` - Array of retrieved context chunks (for RAG systems).
 - `model` - Model identifier (defaults to "gpt-4o" if not specified)
 
@@ -71,6 +75,7 @@ cp .env.example .env
 ```
 
 Edit `.env`:
+
 ```
 GALILEO_API_KEY=your_api_key_here
 GALILEO_CONSOLE_URL=https://app.galileo.ai
@@ -78,6 +83,7 @@ GALILEO_PROJECT=your_project_name
 ```
 
 **Getting your Galileo credentials:**
+
 1. Log in to [Galileo Console](https://app.galileo.ai)
 2. Navigate to Settings → API Keys
 3. Create a new API key or copy an existing one
@@ -94,6 +100,7 @@ python upload_existing_results.py
 ```
 
 The script will:
+
 1. ✅ Load your evaluation data from `dataset.json`
 2. ✅ Create or retrieve a Galileo dataset
 3. ✅ Upload an experiment with full trace reconstruction
@@ -142,25 +149,28 @@ After running the script, your Galileo project will contain:
 ## Troubleshooting
 
 ### "Missing environment variables"
+
 - Make sure you've created a `.env` file with your Galileo credentials
 - Verify all three required variables are set: `GALILEO_API_KEY`, `GALILEO_CONSOLE_URL`, `GALILEO_PROJECT`
 
 ### "Question not found in evaluation data"
+
 - Ensure your JSON file has unique questions
 - Check that there are no extra whitespace or formatting differences
 
 ### Import errors
+
 - Make sure you've activated your virtual environment
 - Run `pip install -r requirements.txt` to install all dependencies
 
 ### "Dataset already exists"
+
 - The script will automatically use existing datasets with the same name
 - To create a fresh dataset, change `DATASET_NAME` in the script
 
 ## Learn More
 
-- [Galileo Documentation](https://v2docs.galileo.ai/what-is-galileo)
-- [Galileo SDK Reference](https://v2docs.galileo.ai/sdk-api/overview)
-- [Creating Custom Metrics](https://v2docs.galileo.ai/concepts/metrics/custom-metrics/custom-metrics-ui-llm)
-- [Understanding Experiments](https://v2docs.galileo.ai/sdk-api/experiments/experiments)
-
+- [Galileo Documentation](https://docs.galileo.ai/what-is-galileo)
+- [Galileo SDK Reference](https://docs.galileo.ai/sdk-api/overview)
+- [Creating Custom Metrics](https://docs.galileo.ai/concepts/metrics/custom-metrics/custom-metrics-ui-llm)
+- [Understanding Experiments](https://docs.galileo.ai/sdk-api/experiments/experiments)

--- a/python/logging-samples/galileologger/README.md
+++ b/python/logging-samples/galileologger/README.md
@@ -1,6 +1,6 @@
 # GalileoLogger Examples
 
-The examples in this folder demonstrates how to use [`GalileoLogger`](https://v2docs.galileo.ai/sdk-api/python/reference/logger/logger) to log data to Galileo. Other ways of logging to Galileo can be found in [how-to guides](https://v2docs.galileo.ai/how-to-guides/basics/basic-example).
+The examples in this folder demonstrates how to use [`GalileoLogger`](https://docs.galileo.ai/sdk-api/python/reference/logger/logger) to log data to Galileo. Other ways of logging to Galileo can be found in [how-to guides](https://docs.galileo.ai/how-to-guides/basics/basic-example).
 
 ## Setup Instructions
 
@@ -14,10 +14,11 @@ cd python/logging-samples/galileologger
 python -m venv venv
 
 # Activate virtual environment
-source venv/bin/activate 
+source venv/bin/activate
 ```
 
 ### 2. Install Dependencies
+
 Run
 
 ```bash
@@ -25,7 +26,9 @@ pip install -r requirements.txt
 ```
 
 ### 3. Configure Environment Variables
+
 Your `.env` should look like this. Feel free to follow the `.env.example` and enter your credentials
+
 ```bash
 
 # Required: Your Galileo API key
@@ -47,15 +50,13 @@ Run the basic example:
 python basic-example.py
 ```
 
-This example's expected output includes the Galileo URL of the log stream. 
+This example's expected output includes the Galileo URL of the log stream.
 
 Go to this URL in your browser to confirm the logged data.
 
 Screenshot of the logged data:
 
 ![Screenshot from running the basic example](screenshot-basic-example.png)
-
-
 
 ## Retriever Example
 
@@ -69,13 +70,9 @@ This example logs a more complex trace with multiple spans, including a retrieve
 
 The example's expected output includes the Galileo URL of the log stream. Go to this URL in your browser to confirm the logged data.
 
-
 Screenshot of the logged data:
 
-
 ![Screenshot from running the retriever example](screenshot-retriever-example.png)
-
-
 
 ## Redaction Example
 
@@ -85,20 +82,17 @@ Run the redaction example:
 python redaction-example.py
 ```
 
-This example logs traces with `redacted_input` (input excluding sensitive info such as social security numbers or email adddresses). 
+This example logs traces with `redacted_input` (input excluding sensitive info such as social security numbers or email adddresses).
 
-The optional parameters `redacted_input` and `redacted_output` can be provided to [`GalileoLogger`](https://v2docs.galileo.ai/sdk-api/python/reference/logger/logger) methods such as [`start_trace`](https://v2docs.galileo.ai/sdk-api/python/reference/logger/logger#start_trace) and [`add_retriever_span`](https://v2docs.galileo.ai/sdk-api/python/reference/logger/logger#add_retriever_span).
+The optional parameters `redacted_input` and `redacted_output` can be provided to [`GalileoLogger`](https://docs.galileo.ai/sdk-api/python/reference/logger/logger) methods such as [`start_trace`](https://docs.galileo.ai/sdk-api/python/reference/logger/logger#start_trace) and [`add_retriever_span`](https://docs.galileo.ai/sdk-api/python/reference/logger/logger#add_retriever_span).
 
 The example's expected output includes an export of logged traces, as well as the Galileo URL of the log stream. Go to this URL in your browser to confirm the logged data.
-
 
 Screenshots of the logged data with sensitive info redacted:
 
 ![Screenshot from redaction: ssn example](screenshot-redaction-example-ssn.png)
 
 ![Screenshot from redaction: email example](screenshot-redaction-example-email.png)
-
-
 
 ## Metadata Example
 
@@ -110,16 +104,12 @@ python metadata-example.py
 
 This example logs a session, trace, and span with metadata (optional key-value attributes).
 
-The optional parameter `metadata` can be provided to [`GalileoLogger`](https://v2docs.galileo.ai/sdk-api/python/reference/logger/logger) methods such as [`start_session`](https://v2docs.galileo.ai/sdk-api/python/reference/logger/logger#start_session), [`start_trace`](https://v2docs.galileo.ai/sdk-api/python/reference/logger/logger#start_trace) and [`add_llm_span`](https://v2docs.galileo.ai/sdk-api/python/reference/logger/logger#add_llm_span).
+The optional parameter `metadata` can be provided to [`GalileoLogger`](https://docs.galileo.ai/sdk-api/python/reference/logger/logger) methods such as [`start_session`](https://docs.galileo.ai/sdk-api/python/reference/logger/logger#start_session), [`start_trace`](https://docs.galileo.ai/sdk-api/python/reference/logger/logger#start_trace) and [`add_llm_span`](https://docs.galileo.ai/sdk-api/python/reference/logger/logger#add_llm_span).
 
 The example's expected output includes the Galileo URL of the log stream. Go to this URL in your browser to confirm the logged data.
 
-
 Screenshots of the logged data with metadata:
-
-
 
 ![Screenshot from logs with metadata](screenshot-metadata-logs-view.png)
 
 ![Screenshot from logs with metadata: messages view](screenshot-metadata-messages-view.png)
-

--- a/python/logging-samples/log-mcp-calls/README.md
+++ b/python/logging-samples/log-mcp-calls/README.md
@@ -1,8 +1,8 @@
 # Log MCP calls as tool spans
 
-This is an example project demonstrating how to use Galileo to log MCP server calls as tool spans. This code is described in the [Log MCP Server Tool Calls how-to guide](https://v2docs.galileo.ai/how-to-guides/basics/log-mcp-server-calls/log-mcp-server-calls) in the Galileo documentation.
+This is an example project demonstrating how to use Galileo to log MCP server calls as tool spans. This code is described in the [Log MCP Server Tool Calls how-to guide](https://docs.galileo.ai/how-to-guides/basics/log-mcp-server-calls/log-mcp-server-calls) in the Galileo documentation.
 
-The MCP server used by default is the [Galileo MCP server](https://v2docs.galileo.ai/getting-started/mcp/setup-galileo-mcp), but you can use this code with any MCP server that supports a streamable HTTP connection by changing the `MCP_SERVER_URL` environment variable.
+The MCP server used by default is the [Galileo MCP server](https://docs.galileo.ai/getting-started/mcp/setup-galileo-mcp), but you can use this code with any MCP server that supports a streamable HTTP connection by changing the `MCP_SERVER_URL` environment variable.
 
 ## Getting Started
 

--- a/python/logging-samples/log-mcp-calls/app.py
+++ b/python/logging-samples/log-mcp-calls/app.py
@@ -2,7 +2,7 @@
 A sample application that shows how to log MCP server calls as tool spans.
 
 This code is described in the Log MCP Server Tool Calls how-to guide in the Galileo documentation:
-https://v2docs.galileo.ai/how-to-guides/basics/log-mcp-server-calls/log-mcp-server-calls
+https://docs.galileo.ai/how-to-guides/basics/log-mcp-server-calls/log-mcp-server-calls
 """
 
 import asyncio

--- a/python/rag/elastic-chatbot-rag-app/README.md
+++ b/python/rag/elastic-chatbot-rag-app/README.md
@@ -1,6 +1,6 @@
 # Elastic Chatbot RAG App + Galileo
 
-Read more on how to leverage [Galileo for your chat app](https://v2docs.galileo.ai/cookbooks/use-cases/rag-elastic-langchain-integration)
+Read more on how to leverage [Galileo for your chat app](https://docs.galileo.ai/cookbooks/use-cases/rag-elastic-langchain-integration)
 
 This is a sample app that combines Elasticsearch, Langchain and a number of different LLMs to create a chatbot experience with ELSER with your own private data.
 
@@ -10,9 +10,10 @@ This is a sample app that combines Elasticsearch, Langchain and a number of diff
 
 ## Setup a Galileo project:
 
-On your cluster or [https://app.galileo.ai](https://app.galileo.ai) create an account, a logstream project and api keys. You can follow [this guide](https://v2docs.galileo.ai/concepts/projects#whats-in-a-project).
+On your cluster or [https://app.galileo.ai](https://app.galileo.ai) create an account, a logstream project and api keys. You can follow [this guide](https://docs.galileo.ai/concepts/projects#whats-in-a-project).
 
 Make sure to set your Galileo logging env variables
+
 ```bash
 # Galileo Environment Variables
 GALILEO_API_KEY=your-galileo-api-key             # Your Galileo API key.
@@ -22,7 +23,6 @@ GALILEO_LOG_STREAM=your-galileo-log-stream       # The name of the log stream yo
 # Provide the console url below if you are using a custom deployment, and not using app.galileo.ai
 # GALILEO_CONSOLE_URL=your-galileo-console-url   # Optional if you are using a hosted version of Galileo
 ```
-
 
 ## Download the Project
 
@@ -52,19 +52,20 @@ We support several LLM providers, but only one is used at runtime, and selected
 by the `LLM_TYPE` entry in your `.env` file. Edit that file to choose an LLM,
 and configure its templated connection settings:
 
-* azure: [Azure OpenAI Service](https://learn.microsoft.com/azure/ai-services/openai/)
-* bedrock: [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/)
-* openai: [OpenAI Platform](https://platform.openai.com/docs/overview) and
+- azure: [Azure OpenAI Service](https://learn.microsoft.com/azure/ai-services/openai/)
+- bedrock: [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/)
+- openai: [OpenAI Platform](https://platform.openai.com/docs/overview) and
   services compatible with its API.
-* vertex: [Google Vertex AI](https://cloud.google.com/vertex-ai/docs)
-* mistral: [Mistral AI](https://docs.mistral.ai/)
-* cohere: [Cohere](https://docs.cohere.com/)
+- vertex: [Google Vertex AI](https://cloud.google.com/vertex-ai/docs)
+- mistral: [Mistral AI](https://docs.mistral.ai/)
+- cohere: [Cohere](https://docs.cohere.com/)
 
 ## Running the App
 
 This application contains two services:
-* create-index: Installs ELSER and ingests data into elasticsearch
-* api-frontend: Hosts the chatbot-rag-app application on http://localhost:4000
+
+- create-index: Installs ELSER and ingests data into elasticsearch
+- api-frontend: Hosts the chatbot-rag-app application on http://localhost:4000
 
 There are two ways to run the app: via Docker or locally. Docker is advised for
 ease while locally is advised if you are making changes to the application.
@@ -80,7 +81,7 @@ working Python environment.
 docker compose up --pull always --force-recreate
 ```
 
-*Note*: The first run may take several minutes to become available.
+_Note_: The first run may take several minutes to become available.
 
 Clean up when finished, like this:
 
@@ -100,12 +101,14 @@ copied to a file name `.env` and updated with `ELASTICSEARCH_URL` and
 
 For example, if you started your Elastic Stack with [k8s-manifest-elastic.yml][k8s-manifest-elastic],
 you would update these values:
+
 ```
 ELASTICSEARCH_URL=http://elasticsearch:9200
 OTEL_EXPORTER_OTLP_ENDPOINT=http://apm-server:8200
 ```
 
 Then, import your `.env` file as a configmap like this:
+
 ```bash
 kubectl create configmap chatbot-rag-app-env --from-env-file=.env
 ```
@@ -115,6 +118,7 @@ kubectl create configmap chatbot-rag-app-env --from-env-file=.env
 
 The `api-frontend container` needs access to your Google Cloud credentials.
 Share your `application_default_credentials.json` as a Kubernetes secret:
+
 ```bash
 # Logs you into Google Cloud and creates application_default_credentials.json
 gcloud auth application-default login
@@ -122,31 +126,37 @@ gcloud auth application-default login
 kubectl create secret generic gcloud-credentials \
   --from-file=application_default_credentials.json=$HOME/.config/gcloud/application_default_credentials.json
 ```
+
 </details>
 
 Now that your configuration is applied, create the `chatbot-rag-app` deployment
 and service by applying this manifest:
+
 ```bash
 kubectl apply -f k8s-manifest.yml
 ```
 
 Next, block until `chatbot-rag-app` is available.
+
 ```bash
 kubectl wait --for=condition=available --timeout=20m  deployment/chatbot-rag-app
 ```
 
-*Note*: The first run may take several minutes to become available. Here's how
+_Note_: The first run may take several minutes to become available. Here's how
 to follow logs on this stage:
+
 ```bash
 kubectl logs deployment.apps/chatbot-rag-app -c create-index -f
 ```
 
 Next, forward the web UI port:
+
 ```bash
 kubectl port-forward deployment.apps/chatbot-rag-app 4000:4000 &
 ```
 
 Clean up when finished, like this:
+
 ```bash
 kubectl delete -f k8s-manifest.yml
 ```
@@ -187,15 +197,17 @@ pip install -r requirements.txt
 #### Create your Elasticsearch index
 
 First, ingest the data into elasticsearch:
+
 ```bash
 dotenv run -- flask create-index
 ```
 
-*Note*: This may take several minutes to complete
+_Note_: This may take several minutes to complete
 
 #### Run the application
 
 Now, run the app, which listens on http://localhost:4000
+
 ```bash
 dotenv run -- python api/app.py
 ```
@@ -274,6 +286,7 @@ docker compose up --build --force-recreate
 ```
 
 ---
+
 [loader-docs]: https://python.langchain.com/docs/how_to/#document-loaders
 [install-es]: https://www.elastic.co/search-labs/tutorials/install-elasticsearch
 [docker-compose-elastic]: ../../docker/docker-compose-elastic.yml

--- a/typescript/agent/langgraph-fsi-agent/README.md
+++ b/typescript/agent/langgraph-fsi-agent/README.md
@@ -112,7 +112,7 @@ To run the app, you need the following:
 1. Copy the `.env.example` file to `.env`
 1. Fill in the values
 
-    For the Galileo values, you MUST create the project up front, but the log stream does not need to be created, it will be created automatically
+   For the Galileo values, you MUST create the project up front, but the log stream does not need to be created, it will be created automatically
 
 ### Install the dependencies
 
@@ -144,15 +144,15 @@ The app runs as a simple terminal chatbot.
 
 1. Install the dependencies:
 
-    ```bash
-    npm i
-    ```
+   ```bash
+   npm i
+   ```
 
 1. Run the app
 
-    ```bash
-    npm run start
-    ```
+   ```bash
+   npm run start
+   ```
 
 You can then chat with the terminal:
 
@@ -174,7 +174,7 @@ From there you can configure the metrics you are interested in. Once metrics are
 
 This project also includes a unit test to run the chatbot with a set of defined prompts, evaluating the prompts for action advancement, action completion, tool selection quality, and tool errors, only passing the test if both metrics score an average of 100% (or 0% for tool errors) over all the entries in the dataset.
 
-This is run using the [Galileo experiments framework](https://v2docs.galileo.ai/concepts/experiments/overview) - allowing you to run any code as an experiment against a fixed dataset of prompts. This mechanism allows you to run AI applications, from simple to complex, under test conditions with a defined set of inputs. You can then use the results of evaluations run against your app to help with model selection or prompt engineering, as well as validating your application as part of a CI/CD pipeline.
+This is run using the [Galileo experiments framework](https://docs.galileo.ai/concepts/experiments/overview) - allowing you to run any code as an experiment against a fixed dataset of prompts. This mechanism allows you to run AI applications, from simple to complex, under test conditions with a defined set of inputs. You can then use the results of evaluations run against your app to help with model selection or prompt engineering, as well as validating your application as part of a CI/CD pipeline.
 
 You can run the unit test by running the following command inside your virtual environment:
 

--- a/typescript/agent/stripe-agent-tool/README.md
+++ b/typescript/agent/stripe-agent-tool/README.md
@@ -11,10 +11,10 @@ A self-contained TypeScript agent using Stripe Agent Toolkit with Galileo monito
 - **Buffered Logging**: Galileo traces are buffered and flushed efficiently
 - **Galileo Agent Reliability**: Comprehensive logging and analytics
   - Recommended metrics to use in Galileo to track agent reliability:
-    - [Tool Error](https://v2docs.galileo.ai/concepts/metrics/agentic/tool-error): detects errors or failures during the execution of Tools.
-    - [Tool Selection Quality](https://v2docs.galileo.ai/concepts/metrics/agentic/tool-selection-quality#tool-selection-quality): determines whether the agent selected the correct tool and for each tool the correct arguments.
-    - [Context Adherence](https://v2docs.galileo.ai/concepts/metrics/response-quality/context-adherence): a measurement of closed-domain hallucinations: cases where your model said things that were not provided in the context.
-    - [See all metrics here](https://v2docs.galileo.ai/concepts/metrics/overview)
+    - [Tool Error](https://docs.galileo.ai/concepts/metrics/agentic/tool-error): detects errors or failures during the execution of Tools.
+    - [Tool Selection Quality](https://docs.galileo.ai/concepts/metrics/agentic/tool-selection-quality#tool-selection-quality): determines whether the agent selected the correct tool and for each tool the correct arguments.
+    - [Context Adherence](https://docs.galileo.ai/concepts/metrics/response-quality/context-adherence): a measurement of closed-domain hallucinations: cases where your model said things that were not provided in the context.
+    - [See all metrics here](https://docs.galileo.ai/concepts/metrics/overview)
 - **Interactive Modes**: CLI and web server options
 - **Self-contained**: All dependencies and assets included
 
@@ -52,7 +52,7 @@ stripe-agents-sdk-example/
 - npm or yarn
 - Stripe account with API keys
 - OpenAI API key
-- Galileo account 
+- Galileo account
 
 ## Setup
 
@@ -80,7 +80,7 @@ stripe-agents-sdk-example/
    # Galileo Configuration
    GALILEO_API_KEY=your_galileo_api_key_here           #Your Galileo API Key
    GALILEO_PROJECT=stripe-agent-demo                  #Your Galileo Project Name
-   GALILEO_LOG_STREAM=production                      #Your Galileo Log Stream Name    
+   GALILEO_LOG_STREAM=production                      #Your Galileo Log Stream Name
    # OPTIONAL
    # Provide the console URL below if you are using a custom deployment, and not using app.galileo.ai
    # This is most common with enterprise, or on prem deployments where you may have your own custom cluster
@@ -97,7 +97,7 @@ stripe-agents-sdk-example/
    npm run build
    ```
 
- ## Product Catalog Setup
+## Product Catalog Setup
 
 This project includes a comprehensive space-themed product catalog for "Galileo's Gizmos". To set up the product catalog:
 
@@ -153,7 +153,6 @@ This will create 20 space-themed products including:
 - Cosmic Wall Art
 - Astronaut Alarm Clock
 
-
 ## Usage
 
 ### Interactive CLI Mode
@@ -179,6 +178,7 @@ npm test
 ### Loop Prevention
 
 The agent now includes advanced circular tool usage detection that:
+
 - Monitors the last four tool calls for repeated patterns
 - Detects when tools are being called in loops (e.g., A → B → A → B)
 - Gracefully handles circular calls with appropriate error messages
@@ -187,6 +187,7 @@ The agent now includes advanced circular tool usage detection that:
 ### Conversation Memory
 
 Improved memory system with:
+
 - **five-minute caching** of product and price data
 - **Conversation history** maintained across interactions
 - **Context awareness** using the last 6 messages for better responses
@@ -195,6 +196,7 @@ Improved memory system with:
 ### Buffered Logging
 
 Galileo logging improvements:
+
 - **Buffered traces** are queued and flushed efficiently
 - **Developer override** command `!end` to force flush during testing
 - **Session management** with proper cleanup and error handling
@@ -212,14 +214,15 @@ When using interactive mode, these special commands are available:
 ### API Signature Changes
 
 **AgentExecutor Configuration:**
-```typescript
 
+```typescript
 // Updated configuration
-maxIterations: 8  // Increased to handle complex interactions
-earlyStoppingMethod: 'force'     // Stop when agent decides it's complete
+maxIterations: 8; // Increased to handle complex interactions
+earlyStoppingMethod: "force"; // Stop when agent decides it's complete
 ```
 
 **New Caching Methods:**
+
 ```typescript
 // Cache management
 private isCacheValid(): boolean
@@ -242,7 +245,6 @@ private readonly CACHE_DURATION = 5 * 60 * 1000 // 5 minutes
 - `npm run web` - Start web server mode
 - `npm run test` - Run test suite
 - `npm run setup-products` - Set up space-themed product catalog in Stripe
-
 
 ## BuildOutput
 

--- a/typescript/agent/stripe-agent-tool/TUTORIAL.md
+++ b/typescript/agent/stripe-agent-tool/TUTORIAL.md
@@ -5,6 +5,7 @@ This cookbook demonstrates how to set up and run a complete AI agent that integr
 ## Overview
 
 By the end of this tutorial, you'll have a fully functional AI agent that can:
+
 - List products and prices from Stripe
 - Create payment links for customers
 - Manage customer data
@@ -12,6 +13,7 @@ By the end of this tutorial, you'll have a fully functional AI agent that can:
 - Track all interactions with Galileo observability
 
 ## Prerequisites
+
 - Basic familiarity with TypeScript, Node.js, and the command line
 - Node.js 18+
 - npm or yarn
@@ -21,11 +23,12 @@ By the end of this tutorial, you'll have a fully functional AI agent that can:
   - Galileo (free [developer account](https://app.galileo.ai/sign-up) available)
   - OpenAI API Key (this app should cost less that $5.00 total to run)
 
-Before you start, you'll need to create a new project in Galileo, as well as create Stripe developer sandbox account. 
+Before you start, you'll need to create a new project in Galileo, as well as create Stripe developer sandbox account.
 
-Instructions are below on how to do each of these actions. 
+Instructions are below on how to do each of these actions.
 
-### Create a Galileo [Project](https://v2docs.galileo.ai/concepts/projects)
+### Create a Galileo [Project](https://docs.galileo.ai/concepts/projects)
+
 1. Go to [Galileo Dashboard](https://app.galileo.ai)
 2. Click on "New Project"
 3. Name your project "Stripe Agent"
@@ -34,6 +37,7 @@ Instructions are below on how to do each of these actions.
 6. Paste it into the .env file as GALILEO_PROJECT
 
 ### Create a Stripe Developer Sandbox Account
+
 1. Go to [Stripe Dashboard](https://dashboard.stripe.com/register)
 2. Sign up for a free account
 3. Navigate to the Developers section
@@ -101,11 +105,13 @@ npm run interactive
 ```
 
 This will:
+
 - Initialize the agent with Galileo agent reliability.
 - Start a conversation session
 - Allow you to interact with the agent using natural language
 
 **Example interactions:**
+
 ```
 🚀 You: Show me your products
 🤖 Assistant: Here are some of our products...
@@ -115,6 +121,7 @@ This will:
 ```
 
 **Available Commands:**
+
 - `help` - Show available commands and examples
 - `quit` or `exit` - Exit the application
 - `clear` - Clear the terminal screen
@@ -131,6 +138,7 @@ npm run web
 The application will run on `http://localhost:3000`
 
 **API Endpoint:**
+
 ```bash
 POST /chat
 Content-Type: application/json
@@ -142,13 +150,15 @@ Content-Type: application/json
 ```
 
 ### Automated Demo Mode
-Run the automated demo script to see the agent in action: 
+
+Run the automated demo script to see the agent in action:
 
 ```bash
 npm run dev
 ```
 
 This demonstrates:
+
 - Payment link creation
 - Customer creation
 - Product listing
@@ -211,7 +221,7 @@ private detectCircularToolUsage(intermediateSteps: any[]): void {
     .filter(tool => tool);
 
   const [tool1, tool2, tool3, tool4] = recentTools;
-  
+
   if (tool1 === tool3 && tool2 === tool4 && tool1 !== tool2) {
     const pattern = [tool1, tool2];
     throw new CircularToolError(
@@ -265,11 +275,11 @@ interface SessionContext {
 ### What's Tracked
 
 Your agent automatically tracks:
+
 - All conversations and tool usage
 - Performance metrics and response times
 - Error rates and failure patterns
-- Session information and user interactions
--[Tool selection quality](https://v2docs.galileo.ai/concepts/metrics/agentic/tool-selection-quality) and accuracy
+- Session information and user interactions -[Tool selection quality](https://docs.galileo.ai/concepts/metrics/agentic/tool-selection-quality) and accuracy
 
 ### Viewing Your Data
 
@@ -280,11 +290,11 @@ Your agent automatically tracks:
 
 ### Recommended Metrics
 
-Based on the [Galileo documentation](https://v2docs.galileo.ai/concepts/metrics/overview), consider tracking:
+Based on the [Galileo documentation](https://docs.galileo.ai/concepts/metrics/overview), consider tracking:
 
-- **[Tool Error](https://v2docs.galileo.ai/concepts/metrics/agentic/tool-error)**: Detects errors during tool execution
-- **[Tool Selection Quality](https://v2docs.galileo.ai/concepts/metrics/agentic/tool-selection-quality)**: Determines if the agent selected the correct tool and arguments
-- **[Context Adherence](https://v2docs.galileo.ai/concepts/metrics/response-quality/context-adherence)**: Measures closed-domain hallucinations
+- **[Tool Error](https://docs.galileo.ai/concepts/metrics/agentic/tool-error)**: Detects errors during tool execution
+- **[Tool Selection Quality](https://docs.galileo.ai/concepts/metrics/agentic/tool-selection-quality)**: Determines if the agent selected the correct tool and arguments
+- **[Context Adherence](https://docs.galileo.ai/concepts/metrics/response-quality/context-adherence)**: Measures closed-domain hallucinations
 
 ## Customization
 
@@ -296,7 +306,7 @@ To add new Stripe tools, modify the agent initialization:
 private async initializeAgent(): Promise<void> {
   // Get tools from Stripe toolkit
   const tools = await this.stripeToolkit.getTools();
-  
+
   // Add custom tools if needed
   const customTool = new DynamicTool({
     name: 'custom_tool',
@@ -306,12 +316,12 @@ private async initializeAgent(): Promise<void> {
       return 'Custom tool result';
     },
   });
-  
+
   const allTools = [...tools, customTool];
-  
+
   // Create the agent
   const prompt = await pull("hwchase17/structured-chat-zero-shot-react");
-  
+
   this.agentExecutor = await createStructuredChatAgent({
     llm: this.llm,
     tools: allTools,
@@ -326,7 +336,10 @@ To customize the agent's behavior, modify the prompt template:
 
 ```typescript
 const customPrompt = ChatPromptTemplate.fromMessages([
-  ["system", "You are a helpful Stripe assistant. Always be polite and professional."],
+  [
+    "system",
+    "You are a helpful Stripe assistant. Always be polite and professional.",
+  ],
   ["human", "{input}"],
   ["human", "Chat History: {chat_history}"],
 ]);
@@ -353,6 +366,7 @@ AGENT_DESCRIPTION=Custom agent description
 ### Common Issues
 
 #### 1. "Missing environment variables"
+
 ```bash
 # Check your .env file exists
 ls -la .env
@@ -362,6 +376,7 @@ cat .env | grep -E "(STRIPE|OPENAI|GALILEO)"
 ```
 
 #### 2. "Galileo initialization failed"
+
 ```bash
 # Check your Galileo API key
 echo $GALILEO_API_KEY
@@ -371,6 +386,7 @@ curl -I https://app.galileo.ai
 ```
 
 #### 3. "Stripe API errors"
+
 ```bash
 # Verify your Stripe key format
 echo $STRIPE_SECRET_KEY | grep "sk_test_"
@@ -380,6 +396,7 @@ curl -u $STRIPE_SECRET_KEY: https://api.stripe.com/v1/account
 ```
 
 #### 4. "Agent not responding"
+
 ```bash
 # Check OpenAI API key
 echo $OPENAI_API_KEY
@@ -409,6 +426,7 @@ Force flush Galileo traces:
 ## Next Steps
 
 ### 1. Extend Functionality
+
 - Add more Stripe operations (refunds, subscriptions, etc.)
 - Implement user authentication
 - Add payment webhook handling
@@ -417,7 +435,7 @@ Force flush Galileo traces:
 
 - [Stripe API Documentation](https://stripe.com/docs/api)
 - [LangChain Documentation](https://js.langchain.com/)
-- [Galileo Documentation](https://v2docs.galileo.ai/)
+- [Galileo Documentation](https://docs.galileo.ai/)
 - [OpenAI API Documentation](https://platform.openai.com/docs)
 - [TypeScript Documentation](https://www.typescriptlang.org/docs/)
 
@@ -426,8 +444,8 @@ Force flush Galileo traces:
 If you encounter issues:
 
 1. Check the troubleshooting section above
-2. Review the [Galileo documentation](https://v2docs.galileo.ai/)
+2. Review the [Galileo documentation](https://docs.galileo.ai/)
 3. Open an issue in the repository
 4. Reach out to the Galileo developer team at [devrel@galileo.ai](mailto:devrel@galileo.ai)
 
-Happy building! 🚀 
+Happy building! 🚀

--- a/typescript/agent/stripe-agent-tool/public/index.html
+++ b/typescript/agent/stripe-agent-tool/public/index.html
@@ -630,7 +630,7 @@
                 
                 <a 
                     class="resource-link" 
-                    href="https://v2docs.galileo.ai/what-is-galileo" 
+                    href="https://docs.galileo.ai/what-is-galileo" 
                     target="_blank" 
                     rel="noopener"
                     aria-label="Learn more about Galileo"

--- a/typescript/chatbot/sample-project-chatbot/anthropic/README.md
+++ b/typescript/chatbot/sample-project-chatbot/anthropic/README.md
@@ -20,28 +20,25 @@ To set up this project:
 
 1. Install the required node modules:
 
-    ```bash
-    npm i
-    ```
+   ```bash
+   npm i
+   ```
 
 ### Set up the environment
 
 1. Create a `.env` file by copying the `.env.example` file.
 
 1. Fill in the required values for the Galileo environment variables in the `.env` file:
+   - `GALILEO_API_KEY` - Set this to your Galileo API key
+   - `GALILEO_PROJECT` - Set this to your Galileo Project name
+   - `GALILEO_LOG_STREAM` - Set this to your Galileo Log stream name
 
-    - `GALILEO_API_KEY` - Set this to your Galileo API key
-    - `GALILEO_PROJECT` - Set this to your Galileo Project name
-    - `GALILEO_LOG_STREAM` - Set this to your Galileo Log stream name
-
-    There are also some optional values:
-
-    - `GALILEO_CONSOLE_URL` - If you are using a hosted version of Galileo, set the console URL here. For the free version, remove or comment out this value
+   There are also some optional values:
+   - `GALILEO_CONSOLE_URL` - If you are using a hosted version of Galileo, set the console URL here. For the free version, remove or comment out this value
 
 1. Fill in the required values for your LLM in the `.env` file:
-
-    - Set `ANTHROPIC_API_KEY` to your Anthropic API key
-    - Set `MODEL_NAME` to the name of the model you want to use.
+   - Set `ANTHROPIC_API_KEY` to your Anthropic API key
+   - Set `MODEL_NAME` to the name of the model you want to use.
 
 ## Run the chatbot
 
@@ -69,7 +66,7 @@ These moons are significant for their unique geological features and potential f
 
 Every run of the app is logged as a new session in Galileo, with each prompt and response a separate trace.
 
-To evaluate the chatbot, head to your project and Log stream in the Galileo console. Turn on [instruction adherence](https://v2docs.galileo.ai/concepts/metrics/response-quality/instruction-adherence) and [correctness](https://v2docs.galileo.ai/concepts/metrics/response-quality/correctness) for your Log stream.
+To evaluate the chatbot, head to your project and Log stream in the Galileo console. Turn on [instruction adherence](https://docs.galileo.ai/concepts/metrics/response-quality/instruction-adherence) and [correctness](https://docs.galileo.ai/concepts/metrics/response-quality/correctness) for your Log stream.
 
 Then when you run the chatbot, these metrics will be evaluated.
 

--- a/typescript/chatbot/sample-project-chatbot/azure-inference/README.md
+++ b/typescript/chatbot/sample-project-chatbot/azure-inference/README.md
@@ -20,29 +20,26 @@ To set up this project:
 
 1. Install the required node modules:
 
-    ```bash
-    npm i
-    ```
+   ```bash
+   npm i
+   ```
 
 ### Set up the environment
 
 1. Create a `.env` file by copying the `.env.example` file.
 
 1. Fill in the required values for the Galileo environment variables in the `.env` file:
+   - `GALILEO_API_KEY` - Set this to your Galileo API key
+   - `GALILEO_PROJECT` - Set this to your Galileo Project name
+   - `GALILEO_LOG_STREAM` - Set this to your Galileo Log stream name
 
-    - `GALILEO_API_KEY` - Set this to your Galileo API key
-    - `GALILEO_PROJECT` - Set this to your Galileo Project name
-    - `GALILEO_LOG_STREAM` - Set this to your Galileo Log stream name
-
-    There are also some optional values:
-
-    - `GALILEO_CONSOLE_URL` - If you are using a hosted version of Galileo, set the console URL here. For the free version, remove or comment out this value
+   There are also some optional values:
+   - `GALILEO_CONSOLE_URL` - If you are using a hosted version of Galileo, set the console URL here. For the free version, remove or comment out this value
 
 1. Fill in the required values for your LLM in the `.env` file:
-
-    - Set `AZURE_AI_INFERENCE_ENDPOINT` to your endpoint from AI Foundry
-    - Set `AZURE_AI_INFERENCE_API_KEY` to your API key
-    - Set `MODEL_NAME` to the name of the model deployment you want to use.
+   - Set `AZURE_AI_INFERENCE_ENDPOINT` to your endpoint from AI Foundry
+   - Set `AZURE_AI_INFERENCE_API_KEY` to your API key
+   - Set `MODEL_NAME` to the name of the model deployment you want to use.
 
 ## Run the chatbot
 
@@ -70,7 +67,7 @@ These moons are significant for their unique geological features and potential f
 
 Every run of the app is logged as a new session in Galileo, with each prompt and response a separate trace.
 
-To evaluate the chatbot, head to your project and Log stream in the Galileo console. Turn on [instruction adherence](https://v2docs.galileo.ai/concepts/metrics/response-quality/instruction-adherence) and [correctness](https://v2docs.galileo.ai/concepts/metrics/response-quality/correctness) for your Log stream.
+To evaluate the chatbot, head to your project and Log stream in the Galileo console. Turn on [instruction adherence](https://docs.galileo.ai/concepts/metrics/response-quality/instruction-adherence) and [correctness](https://docs.galileo.ai/concepts/metrics/response-quality/correctness) for your Log stream.
 
 Then when you run the chatbot, these metrics will be evaluated.
 

--- a/typescript/chatbot/sample-project-chatbot/openai-ollama/README.md
+++ b/typescript/chatbot/sample-project-chatbot/openai-ollama/README.md
@@ -20,25 +20,24 @@ To set up this project:
 
 1. Install the required node modules:
 
-    ```bash
-    npm i
-    ```
+   ```bash
+   npm i
+   ```
 
 ### Set up the environment
 
 1. Create a `.env` file by copying the `.env.example` file.
 
 1. Set the `LLM` to the LLM you are using:
-    - `OpenAI`: Use the OpenAI or Ollama client.
-    - `Anthropic`: Use the Anthropic client.
-    - `Azure`: Use the Azure AI Inference client.
+   - `OpenAI`: Use the OpenAI or Ollama client.
+   - `Anthropic`: Use the Anthropic client.
+   - `Azure`: Use the Azure AI Inference client.
 
 1. Fill in the required values for your LLM in the `.env` file:
-
-    - For OpenAI or other compatible API, set `OPENAI_API_KEY` to your API key.
-    - If you are using a custom OpenAI API deployment or compatible API, set `OPENAI_BASE_URL` to the relevant URL.
-    - For Ollama, set `OPENAI_API_KEY` to `ollama`, set `OPENAI_BASE_URL` to `http://localhost:11434/v1`
-    - Set the `MODEL_NAME` to the name of the model you want to use.
+   - For OpenAI or other compatible API, set `OPENAI_API_KEY` to your API key.
+   - If you are using a custom OpenAI API deployment or compatible API, set `OPENAI_BASE_URL` to the relevant URL.
+   - For Ollama, set `OPENAI_API_KEY` to `ollama`, set `OPENAI_BASE_URL` to `http://localhost:11434/v1`
+   - Set the `MODEL_NAME` to the name of the model you want to use.
 
 ## Run the chatbot
 
@@ -66,7 +65,7 @@ These moons are significant for their unique geological features and potential f
 
 Every run of the app is logged as a new session in Galileo, with each prompt and response a separate trace.
 
-To evaluate the chatbot, head to your project and Log stream in the Galileo console. Turn on [instruction adherence](https://v2docs.galileo.ai/concepts/metrics/response-quality/instruction-adherence) and [correctness](https://v2docs.galileo.ai/concepts/metrics/response-quality/correctness) for your Log stream.
+To evaluate the chatbot, head to your project and Log stream in the Galileo console. Turn on [instruction adherence](https://docs.galileo.ai/concepts/metrics/response-quality/instruction-adherence) and [correctness](https://docs.galileo.ai/concepts/metrics/response-quality/correctness) for your Log stream.
 
 Then when you run the chatbot, these metrics will be evaluated.
 

--- a/typescript/experiments/rag-and-tools/README.md
+++ b/typescript/experiments/rag-and-tools/README.md
@@ -2,7 +2,7 @@
 
 This is an example project demonstrating how to use Galileo experiments with applications that use RAG and tools.
 
-This code is used in the [Run an experiment against a RAG app](http://v2docs.galileo.ai/how-to-guides/experiments/rag-app/rag-app) how-to guide in the Galileo documentation.
+This code is used in the [Run an experiment against a RAG app](http://docs.galileo.ai/how-to-guides/experiments/rag-app/rag-app) how-to guide in the Galileo documentation.
 
 ## Get Started
 


### PR DESCRIPTION
Updates all `v2docs.galileo.ai` links to `docs.galileo.ai` following the migration of v2 docs to the docs subdomain.