### PR TITLE
[DO NOT MERGE] feat(examples): rename GALILEO_* env vars to SPLUNK_AO_* (HYBIM-713, 716, 727)

### DIFF
--- a/docs/SPLUNK_AO_ENV_RENAME.md
+++ b/docs/SPLUNK_AO_ENV_RENAME.md
@@ -1,0 +1,176 @@
+# Spec: Rename `GALILEO_*` Environment Variables to `SPLUNK_AO_*`
+
+**Jira Tickets:** [HYBIM-713](https://splunk.atlassian.net/browse/HYBIM-713) · [HYBIM-716](https://splunk.atlassian.net/browse/HYBIM-716) · [HYBIM-727](https://splunk.atlassian.net/browse/HYBIM-727)  
+**Status:** Draft / In Review  
+**Author:** Aditya Mehra  
+**Date:** 2026-06-04
+
+---
+
+> **Repository migration notice**  
+> The changes in this PR are authored against the current `rungalileo/galileo-python` repository.  
+> Once the Splunk Agent Observability (Splunk AO) project is formally open-sourced, this code will
+> be re-homed to **[signalfx/splunk-ao-python](https://github.com/signalfx/splunk-ao-python)** on
+> GitHub. A corresponding notice applies to the companion PRs:
+> - `sdk-examples` → `signalfx/splunk-ao-python-examples`
+> - `e2e-testing` → internal Splunk AO QA repo
+>
+> These PRs are opened now to facilitate early review. **Do not merge** until the migration is
+> complete and the target repositories exist.
+
+---
+
+## 1. Background
+
+The Galileo Python SDK is being rebranded as part of the **Splunk Agent Observability (Splunk AO)**
+initiative. Environment variables currently prefixed with `GALILEO_` will be replaced with
+`SPLUNK_AO_` to align with Splunk naming conventions and the new product identity.
+
+Tickets in scope for this change:
+
+| Ticket | Title |
+|--------|-------|
+| HYBIM-713 | Rename `GALILEO_API_KEY` → `SPLUNK_AO_API_KEY` |
+| HYBIM-716 | Rename `GALILEO_PROJECT` / `GALILEO_LOG_STREAM` → `SPLUNK_AO_*` |
+| HYBIM-727 | Rename remaining `GALILEO_*` env vars to `SPLUNK_AO_*` |
+
+> **Out of scope:** `GALILEO_HEADER_PREFIX` — tracked separately as [HYBIM-729](https://splunk.atlassian.net/browse/HYBIM-729).
+
+---
+
+## 2. Scope of Changes
+
+### 2.1 Environment Variable Mapping
+
+| Old (`GALILEO_*`) | New (`SPLUNK_AO_*`) |
+|-------------------|---------------------|
+| `GALILEO_API_KEY` | `SPLUNK_AO_API_KEY` |
+| `GALILEO_CONSOLE_URL` | `SPLUNK_AO_CONSOLE_URL` |
+| `GALILEO_PROJECT` | `SPLUNK_AO_PROJECT` |
+| `GALILEO_PROJECT_ID` | `SPLUNK_AO_PROJECT_ID` |
+| `GALILEO_LOG_STREAM` | `SPLUNK_AO_LOG_STREAM` |
+| `GALILEO_LOG_STREAM_ID` | `SPLUNK_AO_LOG_STREAM_ID` |
+| `GALILEO_JWT_TOKEN` | `SPLUNK_AO_JWT_TOKEN` |
+| `GALILEO_SSO_ID_TOKEN` | `SPLUNK_AO_SSO_ID_TOKEN` |
+| `GALILEO_SSO_PROVIDER` | `SPLUNK_AO_SSO_PROVIDER` |
+| `GALILEO_USERNAME` | `SPLUNK_AO_USERNAME` |
+| `GALILEO_PASSWORD` | `SPLUNK_AO_PASSWORD` |
+| `GALILEO_MODE` | `SPLUNK_AO_MODE` |
+| `GALILEO_LOGGING_DISABLED` | `SPLUNK_AO_LOGGING_DISABLED` |
+| `GALILEO_INGEST_BETA_DISABLED` | `SPLUNK_AO_INGEST_BETA_DISABLED` |
+
+### 2.2 Compatibility Strategy
+
+This is a **hard cut-over** — only `SPLUNK_AO_*` environment variables are supported after this
+change. There is no backward-compatibility shim for external consumers.
+
+**Exception — `galileo-core` bridge:**  
+The `galileo-core` package (a private dependency) continues to read `GALILEO_*` variables
+internally. Until `galileo-core` is updated (tracked separately), the SDK automatically bridges
+`SPLUNK_AO_*` → `GALILEO_*` at startup via `GalileoPythonConfig._bridge_env_vars()`. This is a
+transparent, temporary compatibility layer that does not expose `GALILEO_*` names to SDK consumers.
+
+```python
+# src/galileo/config.py — bridge called inside GalileoPythonConfig.get()
+@staticmethod
+def _bridge_env_vars() -> None:
+    """Copy SPLUNK_AO_* values into GALILEO_* so galileo-core can authenticate.
+    Only sets GALILEO_* if it is not already present — explicit overrides win.
+    """
+    _BRIDGE = [
+        ("SPLUNK_AO_API_KEY",       "GALILEO_API_KEY"),
+        ("SPLUNK_AO_CONSOLE_URL",   "GALILEO_CONSOLE_URL"),
+        ("SPLUNK_AO_PROJECT",       "GALILEO_PROJECT"),
+        ...
+    ]
+    for new_key, old_key in _BRIDGE:
+        if new_key in os.environ and old_key not in os.environ:
+            os.environ[old_key] = os.environ[new_key]
+```
+
+---
+
+## 3. Files Changed
+
+### `galileo-python` (this repo)
+
+| File | Change |
+|------|--------|
+| `src/galileo/configuration.py` | 14 `ConfigKey.env_var` fields renamed |
+| `src/galileo/config.py` | Auth validation + `_bridge_env_vars()` added |
+| `src/galileo/utils/env_helpers.py` | `os.getenv()` calls updated |
+| `src/galileo/utils/decorators/telemetry_toggle.py` | `GALILEO_LOGGING_DISABLED` renamed |
+| `src/galileo/logger/logger.py` | `GALILEO_INGEST_BETA_DISABLED` renamed |
+| `src/galileo/{agent_control,decorator,exceptions,experiment,experiments,log_stream,log_streams,metric,middleware/tracing,otel,projects,prompt,shared/exceptions,utils/singleton}.py` | Docstrings / comments / error strings updated |
+| `src/galileo/README_API_CLIENT.md` | Docs updated |
+| `tests/**` | All `GALILEO_*` references in test files renamed to `SPLUNK_AO_*` |
+
+### `sdk-examples`
+
+| File | Change |
+|------|--------|
+| `python/agent/langchain-agent/.env.example` | Renamed keys to `SPLUNK_AO_*` |
+| `python/agent/langchain-agent/main.py` | `os.environ["GALILEO_*"]` → `os.environ["SPLUNK_AO_*"]` |
+| `python/agent/strands-agents/.env.example` | Renamed keys to `SPLUNK_AO_*` |
+
+### `e2e-testing`
+
+| File | Change |
+|------|--------|
+| `py-sdk-and-ui/.env.example` | New file — `SPLUNK_AO_*` keys, no values |
+
+---
+
+## 4. Testing
+
+### Unit Tests
+
+```bash
+cd galileo-python
+poetry run pytest                # 2015 passed, 5 skipped
+```
+
+### E2E Tests
+
+```bash
+cd e2e-testing/py-sdk-and-ui
+poetry run playwright install --with-deps
+poetry run pytest tests/ -k "langchain" --headed
+```
+
+Result: all targeted tests passed (one pre-existing 404 on `test_log_session_with_multiple_traces`
+is a server-side issue unrelated to this change).
+
+### Examples
+
+```bash
+# langchain-agent
+cd sdk-examples/python/agent/langchain-agent
+source .venv/bin/activate && python main.py
+# → "Hello, Erin! 👋"   exit 0
+
+# strands-agents
+cd sdk-examples/python/agent/strands-agents
+source .venv/bin/activate && python agent.py
+# → Tool results returned   exit 0
+```
+
+---
+
+## 5. Decisions & Rationale
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Backward compatibility | Hard cut-over | No dual-support maintenance burden; clean break aligned with rebrand |
+| `galileo-core` handling | Bridge only in SDK | `galileo-core` changes tracked separately; bridge is transparent to consumers |
+| `GALILEO_HEADER_PREFIX` | **Not renamed** | Separate ticket HYBIM-729 |
+| Test files | Renamed to `SPLUNK_AO_*` | Consistency; tests document the new public API |
+
+---
+
+## 6. Open Questions / Follow-ups
+
+- [ ] Update `galileo-core` to read `SPLUNK_AO_*` natively and remove `_bridge_env_vars()`
+- [ ] Rename `GALILEO_HEADER_PREFIX` (HYBIM-729)
+- [ ] Update CI/CD secrets and deployment configs to use `SPLUNK_AO_*` names
+- [ ] Migrate this repo to `signalfx/splunk-ao-python`

--- a/python/agent/RUNNING_EXAMPLES.md
+++ b/python/agent/RUNNING_EXAMPLES.md
@@ -1,0 +1,152 @@
+# Running the Splunk AO Python SDK Examples
+
+This document covers the two agent examples verified working against a self-hosted Splunk AO
+(formerly Galileo) deployment. Copy `.env.example` to `.env`, fill in the values, and run.
+
+---
+
+## Prerequisites
+
+| Requirement | Detail |
+|---|---|
+| Python | 3.10 or newer (examples were run with **3.13**) |
+| Network | Access to your Splunk AO instance |
+| Splunk AO UI | Your `SPLUNK_AO_CONSOLE_URL` |
+
+---
+
+## Example 1 — LangChain Agent (Splunk AO SDK)
+
+**Path:** `python/agent/langchain-agent/`
+
+Uses the `galileo` Python SDK directly (`galileo_context` + `GalileoCallback`).
+Traces are sent via the Splunk AO REST API.
+
+### .env file
+
+Copy `.env.example` to `.env` and fill in your values:
+
+```ini
+# ── Splunk AO ─────────────────────────────────────────────────────────────────
+SPLUNK_AO_API_KEY=<your-api-key>
+SPLUNK_AO_PROJECT=<your-project-name>
+SPLUNK_AO_LOG_STREAM=<your-log-stream-name>
+
+# Self-hosted deployments only:
+# SPLUNK_AO_CONSOLE_URL=https://<your-splunk-ao-host>
+
+# ── LLM Provider ──────────────────────────────────────────────────────────────
+# Option A – standard OpenAI
+# OPENAI_API_KEY=<your-key>
+# OPENAI_MODEL=gpt-4o-mini
+
+# Option B – Azure OpenAI
+# OPENAI_API_KEY=<azure-key>
+# OPENAI_BASE_URL=https://<resource>.cognitiveservices.azure.com/openai/v1/
+# OPENAI_MODEL=gpt-4o-mini
+```
+
+### Setup and run
+
+```bash
+cd python/agent/langchain-agent
+
+# Create venv (Python 3.10+ required)
+python3 -m venv .venv
+source .venv/bin/activate
+
+# Install dependencies
+pip install --index-url https://pypi.org/simple -r requirements.txt
+
+# Run
+python main.py
+```
+
+### Expected output
+
+```
+Agent Response:
+Hello, Erin! 👋
+```
+
+Exit code 0 with no errors means traces were flushed successfully.
+
+---
+
+## Example 2 — Strands Agent (OpenTelemetry / OTLP)
+
+**Path:** `python/agent/strands-agents/`
+
+Uses the `strands-agents` SDK with OpenTelemetry. Spans are exported in OTLP format
+directly to the Splunk AO OTel endpoint — no Galileo SDK is imported.
+
+### .env file
+
+Copy `.env.example` to `.env` and fill in your values:
+
+```ini
+# ── LLM Provider ──────────────────────────────────────────────────────────────
+# Option A: AWS Bedrock (default Strands provider)
+# AWS_BEARER_TOKEN_BEDROCK=<token>
+
+# Option B: Azure OpenAI
+# OPENAI_API_KEY=<azure-key>
+# OPENAI_BASE_URL=https://<resource>.cognitiveservices.azure.com/openai/v1/
+# OPENAI_MODEL=gpt-4o-mini
+
+# ── Splunk AO ─────────────────────────────────────────────────────────────────
+SPLUNK_AO_API_KEY=<your-api-key>
+SPLUNK_AO_PROJECT=<your-project-name>
+SPLUNK_AO_LOG_STREAM=<your-log-stream-name>
+
+# Self-hosted OTel endpoint (leave unset for Splunk AO Cloud):
+# SPLUNK_AO_API_ENDPOINT=https://<splunk-ao-api-host>/otel/traces
+```
+
+### Setup and run
+
+```bash
+cd python/agent/strands-agents
+
+# Create venv (Python 3.10+ required)
+python3 -m venv .venv
+source .venv/bin/activate
+
+# Install dependencies
+pip install --index-url https://pypi.org/simple -r requirements.txt
+
+# Run
+python agent.py
+```
+
+### Expected output
+
+```
+Tool #1: current_time
+Tool #2: calculator
+Tool #3: letter_counter
+Here are the results for your requests:
+1. The current time is <ISO timestamp>.
+2. The result of 3111696 / 74088 is 42.
+3. The number of letter R's in "strawberry" is 3.
+```
+
+Exit code 0 with no Python exceptions means the OTel spans were exported.
+
+---
+
+## Key notes
+
+1. **pip index** — If the system pip is configured with a private registry, pass
+   `--index-url https://pypi.org/simple` when installing to avoid 401 errors.
+
+2. **Python version** — `strands-agents` uses `dataclasses(kw_only=True)` which requires
+   Python 3.10+. The system default may be older; use a version manager (pyenv, etc.).
+
+3. **Self-hosted API URL** — The `galileo` SDK derives the API URL from `SPLUNK_AO_CONSOLE_URL`.
+   If auto-derivation produces the wrong URL for your deployment, set `GALILEO_API_URL` explicitly
+   (this will be renamed to `SPLUNK_AO_API_URL` in a follow-up ticket).
+
+4. **OTel endpoint variable** — `agent.py` reads `SPLUNK_AO_API_ENDPOINT` and assigns it to
+   `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` at runtime. The `.env` file is the only place you need
+   to change the endpoint.

--- a/python/agent/langchain-agent/.env.example
+++ b/python/agent/langchain-agent/.env.example
@@ -1,9 +1,17 @@
-# Galileo Environment Variables
-GALILEO_API_KEY=your-galileo-api-key             # Your Galileo API key.
-GALILEO_PROJECT=your-galileo-project-name        # Your Galileo project name.
-GALILEO_LOG_STREAM=your-galileo-log-stream       # The name of the log stream you want to use for logging.
+# ── Splunk AO ─────────────────────────────────────────────────────────────────
+SPLUNK_AO_API_KEY=                        # Your Splunk AO API key
+SPLUNK_AO_PROJECT=                        # Project name (will be created if absent)
+SPLUNK_AO_LOG_STREAM=                     # Log-stream / run name
 
-# Provide the console url below if you are using a custom deployment, and not using app.galileo.ai
-# GALILEO_CONSOLE_URL=your-galileo-console-url   # Optional if you are using a hosted version of Galileo
+# Self-hosted deployments only:
+# SPLUNK_AO_CONSOLE_URL=https://<your-splunk-ao-host>
 
-OPENAI_API_KEY=your-openai-key-here
+# ── LLM Provider ──────────────────────────────────────────────────────────────
+# Option A – standard OpenAI
+# OPENAI_API_KEY=
+# OPENAI_MODEL=gpt-4o-mini
+
+# Option B – Azure OpenAI (or any OpenAI-compatible endpoint)
+# OPENAI_API_KEY=
+# OPENAI_BASE_URL=https://<resource>.cognitiveservices.azure.com/openai/v1/
+# OPENAI_MODEL=gpt-4o-mini

--- a/python/agent/langchain-agent/main.py
+++ b/python/agent/langchain-agent/main.py
@@ -1,14 +1,16 @@
-from dotenv import load_dotenv
-from langchain.agents import initialize_agent, Tool
-from langchain.agents.agent_types import AgentType
-from langchain_openai import ChatOpenAI
-from langchain.tools import tool
-from galileo import galileo_context
-from galileo.handlers.langchain import GalileoCallback
 import os
 
-# Load environment variables (e.g., API keys)
+from dotenv import load_dotenv
+
+# Load environment variables before anything imports galileo so the env vars
+# are present when pydantic-settings initialises GalileoConfig.
 load_dotenv()
+
+from langchain.agents import create_agent
+from langchain.tools import tool
+from langchain_openai import ChatOpenAI
+from galileo import galileo_context
+from galileo.handlers.langchain import GalileoCallback
 
 
 # Define a tool for the agent to use
@@ -19,14 +21,26 @@ def greet(name: str) -> str:
 
 
 # Use the Galileo context manager to specify project and log stream
-with galileo_context(project="langchain-docs", log_stream="my_log_stream"):
-    agent = initialize_agent(
+with galileo_context(
+    project=os.environ["SPLUNK_AO_PROJECT"],
+    log_stream=os.environ["SPLUNK_AO_LOG_STREAM"],
+):
+    llm = ChatOpenAI(
+        model=os.environ.get("OPENAI_MODEL", "gpt-4o-mini"),
+        temperature=0.7,
+    )
+
+    agent = create_agent(
+        model=llm,
         tools=[greet],
-        llm=ChatOpenAI(model="gpt-4", temperature=0.7, callbacks=[GalileoCallback()]),
-        agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,
-        verbose=True,
+        system_prompt="You are a helpful assistant.",
     )
 
     if __name__ == "__main__":
-        result = agent.invoke({"input": "Say hello to Erin"})
-        print(f"\nAgent Response:\n{result}")
+        result = agent.invoke(
+            {"messages": [{"role": "user", "content": "Say hello to Erin"}]},
+            config={"callbacks": [GalileoCallback()]},
+        )
+        # Extract the final assistant message
+        final = result["messages"][-1].content
+        print(f"\nAgent Response:\n{final}")

--- a/python/agent/strands-agents/.env.example
+++ b/python/agent/strands-agents/.env.example
@@ -1,8 +1,28 @@
-# AWS environment variables
-AWS_BEARER_TOKEN_BEDROCK=
+# ── LLM Provider ──────────────────────────────────────────────────────────────
 
-# Galileo environment variables
-GALILEO_API_ENDPOINT=
-GALILEO_API_KEY=
-GALILEO_PROJECT=
-GALILEO_LOG_STREAM=
+# Option A: AWS Bedrock (default Strands provider)
+# AWS_BEARER_TOKEN_BEDROCK=
+
+# Option B: Azure OpenAI (or any OpenAI-compatible endpoint)
+# OPENAI_API_KEY=
+# OPENAI_BASE_URL=https://<your-resource>.cognitiveservices.azure.com/openai/v1/
+# OPENAI_MODEL=gpt-4o-mini
+
+# ── Splunk AO ─────────────────────────────────────────────────────────────────
+
+SPLUNK_AO_API_KEY=
+SPLUNK_AO_PROJECT=
+SPLUNK_AO_LOG_STREAM=
+
+# OTel endpoint for self-hosted Splunk AO deployments.
+# Leave unset when using Splunk AO Cloud — the default endpoint will be used.
+#
+# For self-hosted deployments the endpoint follows the pattern:
+#   SPLUNK_AO_API_ENDPOINT=https://<splunk-ao-api-host>/otel/traces
+#
+# SPLUNK_AO_API_ENDPOINT=
+
+# ── OTel semantic conventions (optional) ──────────────────────────────────────
+# Opt in to experimental gen_ai semantic conventions for structured
+# input/output events (requires strands-agents >= 1.34.0).
+# OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental

--- a/python/agent/strands-agents/agent.py
+++ b/python/agent/strands-agents/agent.py
@@ -1,6 +1,7 @@
 import os
 
 from strands import Agent, tool
+from strands.models.openai import OpenAIModel
 from strands.telemetry import StrandsTelemetry
 from strands_tools import calculator, current_time
 
@@ -25,7 +26,7 @@ os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = ",".join([f"{k}={v}" for k, v in head
 strands_telemetry = StrandsTelemetry()
 strands_telemetry.setup_otlp_exporter()
 
-# Uncomment this line to see the OTel output in the console
+# Uncomment to print spans to stdout for local debugging
 # strands_telemetry.setup_console_exporter()
 
 
@@ -56,9 +57,18 @@ def letter_counter(word: str, letter: str) -> int:
     return word.lower().count(letter.lower())
 
 
+# Use Azure OpenAI via the OpenAI-compatible endpoint
+model = OpenAIModel(
+    model_id=os.environ["OPENAI_MODEL"],
+    client_args={
+        "base_url": os.environ["OPENAI_BASE_URL"],
+        "api_key": os.environ["OPENAI_API_KEY"],
+    },
+)
+
 # Create an agent with tools from the community-driven strands-tools package
 # as well as our custom letter_counter tool
-agent = Agent(tools=[calculator, current_time, letter_counter])
+agent = Agent(model=model, tools=[calculator, current_time, letter_counter])
 
 # Ask the agent a question that uses the available tools
 message = """

--- a/python/agent/strands-agents/requirements.txt
+++ b/python/agent/strands-agents/requirements.txt
@@ -2,5 +2,5 @@ opentelemetry-api
 opentelemetry-exporter-otlp
 opentelemetry-sdk
 python-dotenv
-strands-agents
+strands-agents[openai]
 strands-agents-tools


### PR DESCRIPTION
## ⚠️ DO NOT MERGE

This PR is opened for **early review only**.

> **Repository migration notice:** Once the Splunk Agent Observability project is formally
> open-sourced, this code will be re-homed to
> **signalfx/splunk-ao-python-examples** on GitHub.
> This PR will be closed and re-opened (or cherry-picked) against that repository.
> Companion PRs:
> - `galileo-python` → [rungalileo/galileo-python#597](https://github.com/rungalileo/galileo-python/pull/597)
> - `e2e-testing` → see separate PR in `rungalileo/e2e-testing`

---

## Summary

Updates Python agent examples to use the renamed `SPLUNK_AO_*` environment variables
introduced as part of the Splunk Agent Observability rebrand.

**Jira tickets:** [HYBIM-713](https://splunk.atlassian.net/browse/HYBIM-713) · [HYBIM-716](https://splunk.atlassian.net/browse/HYBIM-716) · [HYBIM-727](https://splunk.atlassian.net/browse/HYBIM-727)

**Spec doc:** [`docs/SPLUNK_AO_ENV_RENAME.md`](docs/SPLUNK_AO_ENV_RENAME.md)

## Changes

| File | Change |
|------|--------|
| `langchain-agent/.env.example` | `GALILEO_*` → `SPLUNK_AO_*` keys, no credential values |
| `langchain-agent/main.py` | `os.environ["GALILEO_*"]` → `SPLUNK_AO_*` |
| `strands-agents/.env.example` | `GALILEO_*` → `SPLUNK_AO_*` keys, no credential values |
| `strands-agents/agent.py` | env var references updated |
| `RUNNING_EXAMPLES.md` | Updated instructions with placeholder values only |
| `docs/SPLUNK_AO_ENV_RENAME.md` | Spec document added |

## Test plan

- [x] `langchain-agent` example — runs end-to-end, exit 0 (`Hello, Erin! 👋`)
- [x] `strands-agents` example — runs end-to-end, exit 0 (tool results returned)

Made with [Cursor](https://cursor.com)