### PR TITLE
feat(examples): update langchain-agent to use SplunkAOCallback (HYBIM-716) [DO NOT MERGE]

### DIFF
--- a/python/agent/langchain-agent/main.py
+++ b/python/agent/langchain-agent/main.py
@@ -10,7 +10,7 @@ from langchain.agents import create_agent
 from langchain.tools import tool
 from langchain_openai import ChatOpenAI
 from galileo import galileo_context
-from galileo.handlers.langchain import GalileoCallback
+from galileo.handlers.langchain import SplunkAOCallback
 
 
 # Define a tool for the agent to use
@@ -39,7 +39,7 @@ with galileo_context(
     if __name__ == "__main__":
         result = agent.invoke(
             {"messages": [{"role": "user", "content": "Say hello to Erin"}]},
-            config={"callbacks": [GalileoCallback()]},
+            config={"callbacks": [SplunkAOCallback()]},
         )
         # Extract the final assistant message
         final = result["messages"][-1].content


### PR DESCRIPTION
## ⚠️ DO NOT MERGE

This PR is opened for **early review only** and is **stacked on the env var rename PR**
(update langchain-agent to use SplunkAOCallback / `SPLUNK_AO_*` env vars).

> **Repository migration notice:** Once Splunk AO is formally open-sourced, this code will be
> re-homed to the corresponding Splunk repository (e.g., `signalfx/splunk-ao-sdk-examples`).

---

## Summary

Updates the `langchain-agent` example to import and use `SplunkAOCallback` (renamed from
`GalileoCallback`) following the class rename in the core SDK (HYBIM-716).

**Jira ticket:** [HYBIM-716](https://splunk.atlassian.net/browse/HYBIM-716)
**SDK PR:** rungalileo/galileo-python#598

### Changes

- `python/agent/langchain-agent/main.py`: `GalileoCallback` → `SplunkAOCallback`

## Test plan

- [x] `langchain-agent` example runs end-to-end with `SplunkAOCallback` — exit 0

Made with [Cursor](https://cursor.com)