### PR TITLE
feat(examples): rebrand google-adk to SPLUNK_AO_* env vars, add OpenAI provider support

### DIFF
--- a/docs/SPLUNK_AO_ENV_RENAME.md
+++ b/docs/SPLUNK_AO_ENV_RENAME.md
@@ -1,0 +1,90 @@
+# Splunk AO Environment Variable Rename Spec
+
+**Jira:** HYBIM-713 · HYBIM-716 · HYBIM-727  
+**Status:** Implemented
+
+---
+
+## Summary
+
+All `GALILEO_*` environment variables used by the Python SDK examples have been renamed
+to `SPLUNK_AO_*` as part of the Splunk Agent Observability rebrand.
+
+The SDK (`splunk-ao-python`) bridges `SPLUNK_AO_*` → `GALILEO_*` internally so that
+`galileo-core` (an upstream dependency not yet rebranded) continues to work transparently.
+
+---
+
+## Rename Map
+
+| Old (`GALILEO_*`) | New (`SPLUNK_AO_*`) | Used by |
+|---|---|---|
+| `GALILEO_API_KEY` | `SPLUNK_AO_API_KEY` | both |
+| `GALILEO_PROJECT` | `SPLUNK_AO_PROJECT` | both |
+| `GALILEO_LOG_STREAM` | `SPLUNK_AO_LOG_STREAM` | both |
+| `GALILEO_CONSOLE_URL` | `SPLUNK_AO_CONSOLE_URL` | langchain (optional) |
+| `GALILEO_API_URL` | `SPLUNK_AO_API_URL` | langchain |
+| `GALILEO_API_ENDPOINT` | `SPLUNK_AO_API_ENDPOINT` | strands (OTel) |
+
+---
+
+## SDK Bridge (`config.py`)
+
+`SplunkAOConfig._bridge_env_vars()` propagates `SPLUNK_AO_*` values to their `GALILEO_*`
+equivalents at initialisation time. Only bridges values not already set — explicit
+`GALILEO_*` overrides win.
+
+```python
+_BRIDGE = [
+    ("SPLUNK_AO_API_KEY",      "GALILEO_API_KEY"),
+    ("SPLUNK_AO_API_URL",      "GALILEO_API_URL"),
+    ("SPLUNK_AO_CONSOLE_URL",  "GALILEO_CONSOLE_URL"),
+    ("SPLUNK_AO_PROJECT",      "GALILEO_PROJECT"),
+    ("SPLUNK_AO_LOG_STREAM",   "GALILEO_LOG_STREAM"),
+    ...
+]
+```
+
+---
+
+## Code Changes
+
+### `langchain-agent/main.py`
+
+- Import `SplunkAOCallback` from `splunk_ao.handlers.langchain` (handler code moved to
+  `splunk_ao` namespace after rebrand; `galileo.handlers.langchain` is now empty).
+- Read `SPLUNK_AO_PROJECT` / `SPLUNK_AO_LOG_STREAM` directly from env.
+- Move `load_dotenv()` before all SDK imports so env vars are set before
+  pydantic-settings initialises `GalileoConfig`.
+
+### `strands-agents/agent.py`
+
+- Renamed `GALILEO_API_KEY/PROJECT/LOG_STREAM/API_ENDPOINT` reads to `SPLUNK_AO_*`.
+- Move `load_dotenv()` and all `os.environ` assignments before strands imports so OTel
+  env vars are present before `StrandsTelemetry` initialises.
+- Added explicit `strands_telemetry.tracer_provider.shutdown()` at exit.
+  `BatchSpanProcessor` runs a daemon thread — without `shutdown()` pending spans are
+  dropped when the process exits.
+
+### `strands-agents/requirements.txt`
+
+- `strands-agents` → `strands-agents[openai]` (Azure OpenAI model support).
+
+---
+
+## Self-hosted Deployment Notes
+
+### LangChain (SDK / REST API)
+
+`galileo-core` auto-derives the API URL from `GALILEO_CONSOLE_URL` using
+`console_url.replace("console", "api")`. This breaks for hostnames that do not contain
+the substring `"console"` (e.g. `agent-observability.rc0.signalfx.com`).
+
+**Fix:** set `SPLUNK_AO_API_URL` explicitly. The bridge maps it to `GALILEO_API_URL`
+which `galileo-core` uses directly, bypassing auto-derivation.
+
+### Strands (OTLP)
+
+The strands agent sends spans directly to the OTLP HTTP endpoint — no SDK auth flow
+involved. Set `SPLUNK_AO_API_ENDPOINT` to the full `/otel/traces` path.
+`SPLUNK_AO_API_URL` and `SPLUNK_AO_CONSOLE_URL` are irrelevant for strands.

--- a/python/agent/RUNNING_EXAMPLES.md
+++ b/python/agent/RUNNING_EXAMPLES.md
@@ -1,0 +1,165 @@
+# Running the Splunk AO Python SDK Examples
+
+This document covers the two agent examples verified working against self-hosted Splunk AO
+(formerly Galileo) deployments. Copy `.env.example` to `.env`, fill in the values, and run.
+
+---
+
+## Prerequisites
+
+| Requirement | Detail |
+|---|---|
+| Python | 3.10 or newer |
+| Network | Access to your Splunk AO instance |
+
+---
+
+## Example 1 — LangChain Agent (Splunk AO SDK)
+
+**Path:** `python/agent/langchain-agent/`
+
+Uses the Splunk AO Python SDK directly (`galileo_context` + `SplunkAOCallback`).
+Traces are sent via the Splunk AO REST API.
+
+### .env file
+
+Copy `.env.example` to `.env` and fill in your values:
+
+```ini
+# ── Splunk AO ─────────────────────────────────────────────────────────────────
+SPLUNK_AO_API_KEY=<your-api-key>
+SPLUNK_AO_PROJECT=<your-project-name>
+SPLUNK_AO_LOG_STREAM=<your-log-stream-name>
+
+# Required for self-hosted deployments:
+SPLUNK_AO_API_URL=https://<splunk-ao-api-host>
+
+# ── LLM Provider ──────────────────────────────────────────────────────────────
+# Option A – standard OpenAI
+# OPENAI_API_KEY=<your-key>
+# OPENAI_MODEL=gpt-4o-mini
+
+# Option B – Azure OpenAI
+# OPENAI_API_KEY=<azure-key>
+# OPENAI_BASE_URL=https://<resource>.cognitiveservices.azure.com/openai/v1/
+# OPENAI_MODEL=gpt-4o-mini
+```
+
+### Minimum required vars
+
+| Var | Purpose |
+|---|---|
+| `SPLUNK_AO_API_KEY` | Authentication |
+| `SPLUNK_AO_PROJECT` | Project to log traces into |
+| `SPLUNK_AO_LOG_STREAM` | Log stream to log traces into |
+| `SPLUNK_AO_API_URL` | API host for self-hosted deployments (see note below) |
+
+> **Self-hosted API URL** — The SDK cannot auto-derive the API URL for most Splunk AO
+> deployment hostnames. Set `SPLUNK_AO_API_URL` explicitly.
+> `SPLUNK_AO_CONSOLE_URL` is only needed as a fallback when `SPLUNK_AO_API_URL` is absent.
+
+### Setup and run
+
+```bash
+cd python/agent/langchain-agent
+
+python3 -m venv .venv
+source .venv/bin/activate
+
+pip install --index-url https://pypi.org/simple -r requirements.txt
+
+python main.py
+```
+
+### Expected output
+
+```
+Agent Response:
+Hello, Erin! 👋
+```
+
+Exit code 0 with no errors means traces were flushed successfully.
+
+---
+
+## Example 2 — Strands Agent (OpenTelemetry / OTLP)
+
+**Path:** `python/agent/strands-agents/`
+
+Uses the `strands-agents` SDK with OpenTelemetry. Spans are exported in OTLP format
+directly to the Splunk AO OTel endpoint — no Galileo SDK is imported.
+
+### .env file
+
+Copy `.env.example` to `.env` and fill in your values:
+
+```ini
+# ── Splunk AO ─────────────────────────────────────────────────────────────────
+SPLUNK_AO_API_KEY=<your-api-key>
+SPLUNK_AO_PROJECT=<your-project-name>
+SPLUNK_AO_LOG_STREAM=<your-log-stream-name>
+
+# Required for self-hosted deployments:
+SPLUNK_AO_API_ENDPOINT=https://<splunk-ao-api-host>/otel/traces
+
+# ── LLM Provider ──────────────────────────────────────────────────────────────
+# Option B: Azure OpenAI
+OPENAI_API_KEY=<azure-key>
+OPENAI_BASE_URL=https://<resource>.cognitiveservices.azure.com/openai/v1/
+OPENAI_MODEL=gpt-4o-mini
+```
+
+### Minimum required vars
+
+| Var | Purpose |
+|---|---|
+| `SPLUNK_AO_API_KEY` | Sent as `Galileo-API-Key` OTLP header |
+| `SPLUNK_AO_PROJECT` | Sent as `project` OTLP header |
+| `SPLUNK_AO_LOG_STREAM` | Sent as `logstream` OTLP header |
+| `SPLUNK_AO_API_ENDPOINT` | OTLP HTTP endpoint; defaults to `https://api.galileo.ai/otel/traces` |
+
+> **Span flushing** — `agent.py` calls `strands_telemetry.tracer_provider.shutdown()`
+> at exit. This is required: `BatchSpanProcessor` runs a daemon thread that is killed
+> before flushing if `shutdown()` is not called explicitly.
+
+### Setup and run
+
+```bash
+cd python/agent/strands-agents
+
+python3 -m venv .venv
+source .venv/bin/activate
+
+pip install --index-url https://pypi.org/simple -r requirements.txt
+
+python agent.py
+```
+
+### Expected output
+
+```
+Tool #1: current_time
+Tool #2: calculator
+Tool #3: letter_counter
+Here are the results for your requests:
+1. The current time is <ISO timestamp>.
+2. The result of 3111696 / 74088 is 42.
+3. The number of letter R's in "strawberry" is 3.
+```
+
+Exit code 0 with no Python exceptions means the OTel spans were exported.
+
+---
+
+## Notes
+
+1. **pip index** — If the system pip is configured with a private registry, pass
+   `--index-url https://pypi.org/simple` when installing to avoid 401 errors.
+
+2. **Python version** — `strands-agents` uses `dataclasses(kw_only=True)` which requires
+   Python 3.10+.
+
+3. **LangChain vs Strands env vars** — These examples use different mechanisms:
+   - LangChain uses the Splunk AO REST API → needs `SPLUNK_AO_API_URL`
+   - Strands uses OTLP directly → needs `SPLUNK_AO_API_ENDPOINT`
+   Neither needs `SPLUNK_AO_CONSOLE_URL` when the API URL/endpoint is set explicitly.

--- a/python/agent/google-adk/README.md
+++ b/python/agent/google-adk/README.md
@@ -1,55 +1,62 @@
-# Google ADK + OpenTelemetry Example Project
+# Google ADK + Splunk AO Example Project
 
-This is an example project demonstrating how to use Galileo with the Google ADK. This uses the simple [quickstart from the Google ADK documentation](https://google.github.io/adk-docs/get-started/python/#create-an-agent-project), and adds Galileo logging.
+This is an example project demonstrating how to use Splunk Agent Observability (Splunk AO) with the Google ADK. This uses the simple [quickstart from the Google ADK documentation](https://google.github.io/adk-docs/get-started/python/#create-an-agent-project), and adds Splunk AO tracing.
 
 ## Getting Started
 
 To get started with this project, you'll need to have Python 3.10 or later installed. You can then install the required dependencies in a virtual environment:
 
 ```bash
-pip install -r requirements.txt
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --index-url https://pypi.org/simple -r requirements.txt
 ```
 
 ## Configure environment variables
 
-You will need to configure environment variables to use this project. Copy the `.env.example` file to `.env`, then update the environment variables in the `.env` file with your Google and Galileo values:
+You will need to configure environment variables to use this project. Copy the `.env.example` file to `.env`, then update the environment variables in the `.env` file with your values:
 
 ```ini
-# Gemini environment variables
-GOOGLE_GENAI_USE_VERTEXAI=0
-GOOGLE_API_KEY=
+# ── Splunk AO ─────────────────────────────────────────────────────────────────
+SPLUNK_AO_API_KEY=<your-api-key>
+SPLUNK_AO_PROJECT=google-adk
+SPLUNK_AO_LOG_STREAM=<your-log-stream>
 
-# Galileo environment variables
-GALILEO_API_ENDPOINT=
-GALILEO_API_KEY=
-GALILEO_PROJECT=
-GALILEO_LOG_STREAM=
+# Required for self-hosted deployments:
+SPLUNK_AO_API_URL=https://<splunk-ao-api-host>
+
+# ── LLM Provider ──────────────────────────────────────────────────────────────
+# Option A: OpenAI-compatible (Azure OpenAI or standard OpenAI)
+OPENAI_API_KEY=<your-key>
+OPENAI_BASE_URL=https://<resource>.cognitiveservices.azure.com/openai/v1/  # Azure only
+
+# Option B: Google Gemini
+# GOOGLE_GENAI_USE_VERTEXAI=0
+# GOOGLE_API_KEY=<your-google-key>
 ```
 
-For the `GALILEO_API_ENDPOINT`, this is different to the console URL that you would normally use. If you are using `app.galileo.ai` for example, the endpoint is `https://api.galileo.ai/otel/traces`.
-
-See the [Galileo OTel and OpenInference documentation](https://docs.galileo.ai/sdk-api/third-party-integrations/opentelemetry-and-openinference) for more details.
+> **Self-hosted API URL** — `SPLUNK_AO_API_URL` sets the Splunk AO API host directly.
+> This is required for self-hosted deployments where the hostname does not contain
+> `"console"` (e.g. `agent-observability.rc0.signalfx.com`).
 
 ## Usage
 
-Once the dependencies are installed, you can run the example application using the `adk` command:
+Once the dependencies are installed and the `.env` file is configured, run the example using the `adk` command:
 
 ```bash
 adk run my_agent
 ```
 
-Traces will be captured and logged to Galileo.
+Traces will be captured and logged to Splunk AO.
 
 ## Project Structure
 
-The project structure is as follows:
-
-```folder
+```
 google-adk/
 ├── my_agent/          # The main agent application
 │   ├── __init__.py
 │   ├── agent.py
-│   └── env.example    # List of environment variables
+│   └── .env.example   # Environment variable template
 ├── requirements.txt   # Python project requirements
 └── README.md          # Project documentation
 ```

--- a/python/agent/google-adk/my_agent/.env.example
+++ b/python/agent/google-adk/my_agent/.env.example
@@ -1,14 +1,21 @@
-GOOGLE_API_KEY="YOUR_GOOGLE_API_KEY"
-# Your Galileo API key
-GALILEO_API_KEY="YOUR_GALILEO_API_KEY"
+# ── Splunk AO ─────────────────────────────────────────────────────────────────
 
-# Your Galileo project name
-GALILEO_PROJECT="google-adk"
+SPLUNK_AO_API_KEY=
+SPLUNK_AO_PROJECT=google-adk
+SPLUNK_AO_LOG_STREAM=google-adk-log-stream
 
-# The name of the Log stream you want to use for logging
-GALILEO_LOG_STREAM="google-adk-log-stream"
+# Required for self-hosted deployments — set the API host directly.
+# Pattern: https://<splunk-ao-api-host>
+#
+# SPLUNK_AO_API_URL=
 
-# Provide texhe console url below if you are using a
-# custom deployment, and not using the free tier, or app.galileo.ai.
-# This will look something like “console.galileo.yourcompany.com”.
-# GALILEO_CONSOLE_URL="your-galileo-console-url"
+# ── LLM Provider ──────────────────────────────────────────────────────────────
+
+# Option A: standard OpenAI
+# OPENAI_API_KEY=
+# OPENAI_BASE_URL=
+# OPENAI_MODEL=gpt-4o-mini
+
+# Option B: Google Gemini (default ADK provider)
+# GOOGLE_GENAI_USE_VERTEXAI=0
+# GOOGLE_API_KEY=

--- a/python/agent/google-adk/my_agent/agent.py
+++ b/python/agent/google-adk/my_agent/agent.py
@@ -1,17 +1,18 @@
 """Agent logic for the Google ADK example."""
 
+from pathlib import Path
+
 from dotenv import load_dotenv
 from opentelemetry.sdk import trace as trace_sdk
-from galileo import otel
+from splunk_ao.otel import SplunkAOSpanProcessor
 from openinference.instrumentation.google_adk import GoogleADKInstrumentor
-from google.adk.agents.llm_agent import Agent
+from google.adk.agents import LlmAgent
 
-load_dotenv()
+load_dotenv(Path(__file__).parent / ".env")
 
-# Create tracer provider and register Galileo span processor
+# Create tracer provider and register Splunk AO span processor
 tracer_provider = trace_sdk.TracerProvider()
-galileo_span_processor = otel.GalileoSpanProcessor()
-tracer_provider.add_span_processor(galileo_span_processor)
+tracer_provider.add_span_processor(SplunkAOSpanProcessor())
 
 # Instrument Google ADK with OpenInference (this captures inputs/outputs)
 GoogleADKInstrumentor().instrument(tracer_provider=tracer_provider)
@@ -27,10 +28,13 @@ def get_current_time(city: str) -> dict:
     return {"status": "success", "city": city, "time": "10:30 AM"}
 
 
-root_agent = Agent(
-    model="gemini-3-flash-preview",
+root_agent = LlmAgent(
+    model="openai/gpt-4o-mini",
     name="root_agent",
     description="Tells the current time in a specified city.",
-    instruction=("You are a helpful assistant that tells the current time in cities." "Use the 'get_current_time' tool for this purpose."),
+    instruction=(
+        "You are a helpful assistant that tells the current time in cities. "
+        "Use the 'get_current_time' tool for this purpose."
+    ),
     tools=[get_current_time],
 )

--- a/python/agent/google-adk/requirements.txt
+++ b/python/agent/google-adk/requirements.txt
@@ -1,4 +1,8 @@
-google-adk
+google-adk[extensions]
 openinference-instrumentation-google-adk
+opentelemetry-sdk
+opentelemetry-api
+opentelemetry-exporter-otlp
 python-dotenv
 galileo
+litellm>=1.75.5

--- a/python/agent/langchain-agent/.env.example
+++ b/python/agent/langchain-agent/.env.example
@@ -1,9 +1,22 @@
-# Galileo Environment Variables
-GALILEO_API_KEY=your-galileo-api-key             # Your Galileo API key.
-GALILEO_PROJECT=your-galileo-project-name        # Your Galileo project name.
-GALILEO_LOG_STREAM=your-galileo-log-stream       # The name of the log stream you want to use for logging.
+# ── Splunk AO ─────────────────────────────────────────────────────────────────
 
-# Provide the console url below if you are using a custom deployment, and not using app.galileo.ai
-# GALILEO_CONSOLE_URL=your-galileo-console-url   # Optional if you are using a hosted version of Galileo
+SPLUNK_AO_API_KEY=
+SPLUNK_AO_PROJECT=
+SPLUNK_AO_LOG_STREAM=
 
-OPENAI_API_KEY=your-openai-key-here
+# Required for self-hosted deployments — the SDK cannot auto-derive the API URL
+# from the console hostname for most Splunk AO deployments.
+# Pattern: https://<splunk-ao-api-host>
+#
+# SPLUNK_AO_API_URL=
+
+# ── LLM Provider ──────────────────────────────────────────────────────────────
+
+# Option A: standard OpenAI
+# OPENAI_API_KEY=
+# OPENAI_MODEL=gpt-4o-mini
+
+# Option B: Azure OpenAI (or any OpenAI-compatible endpoint)
+# OPENAI_API_KEY=
+# OPENAI_BASE_URL=https://<your-resource>.cognitiveservices.azure.com/openai/v1/
+# OPENAI_MODEL=gpt-4o-mini

--- a/python/agent/langchain-agent/main.py
+++ b/python/agent/langchain-agent/main.py
@@ -1,14 +1,16 @@
-from dotenv import load_dotenv
-from langchain.agents import initialize_agent, Tool
-from langchain.agents.agent_types import AgentType
-from langchain_openai import ChatOpenAI
-from langchain.tools import tool
-from galileo import galileo_context
-from galileo.handlers.langchain import GalileoCallback
 import os
 
-# Load environment variables (e.g., API keys)
+from dotenv import load_dotenv
+
+# Load environment variables before anything imports galileo so the env vars
+# are present when pydantic-settings initialises GalileoConfig.
 load_dotenv()
+
+from langchain.agents import create_agent
+from langchain.tools import tool
+from langchain_openai import ChatOpenAI
+from galileo import galileo_context
+from splunk_ao.handlers.langchain import SplunkAOCallback
 
 
 # Define a tool for the agent to use
@@ -19,14 +21,26 @@ def greet(name: str) -> str:
 
 
 # Use the Galileo context manager to specify project and log stream
-with galileo_context(project="langchain-docs", log_stream="my_log_stream"):
-    agent = initialize_agent(
+with galileo_context(
+    project=os.environ["SPLUNK_AO_PROJECT"],
+    log_stream=os.environ["SPLUNK_AO_LOG_STREAM"],
+):
+    llm = ChatOpenAI(
+        model=os.environ.get("OPENAI_MODEL", "gpt-4o-mini"),
+        temperature=0.7,
+    )
+
+    agent = create_agent(
+        model=llm,
         tools=[greet],
-        llm=ChatOpenAI(model="gpt-4", temperature=0.7, callbacks=[GalileoCallback()]),
-        agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,
-        verbose=True,
+        system_prompt="You are a helpful assistant.",
     )
 
     if __name__ == "__main__":
-        result = agent.invoke({"input": "Say hello to Erin"})
-        print(f"\nAgent Response:\n{result}")
+        result = agent.invoke(
+            {"messages": [{"role": "user", "content": "Say hello to Erin"}]},
+            config={"callbacks": [SplunkAOCallback()]},
+        )
+        # Extract the final assistant message
+        final = result["messages"][-1].content
+        print(f"\nAgent Response:\n{final}")

--- a/python/agent/strands-agents/.env.example
+++ b/python/agent/strands-agents/.env.example
@@ -1,8 +1,28 @@
-# AWS environment variables
-AWS_BEARER_TOKEN_BEDROCK=
+# ── Splunk AO ─────────────────────────────────────────────────────────────────
 
-# Galileo environment variables
-GALILEO_API_ENDPOINT=
-GALILEO_API_KEY=
-GALILEO_PROJECT=
-GALILEO_LOG_STREAM=
+SPLUNK_AO_API_KEY=
+SPLUNK_AO_PROJECT=
+SPLUNK_AO_LOG_STREAM=
+
+# OTel endpoint for self-hosted Splunk AO deployments.
+# Leave unset when using Splunk AO Cloud — the default endpoint will be used.
+#
+# For self-hosted deployments the endpoint follows the pattern:
+#   SPLUNK_AO_API_ENDPOINT=https://<splunk-ao-api-host>/otel/traces
+#
+# SPLUNK_AO_API_ENDPOINT=
+
+# ── LLM Provider ──────────────────────────────────────────────────────────────
+
+# Option A: AWS Bedrock (default Strands provider)
+# AWS_BEARER_TOKEN_BEDROCK=
+
+# Option B: Azure OpenAI (or any OpenAI-compatible endpoint)
+# OPENAI_API_KEY=
+# OPENAI_BASE_URL=https://<your-resource>.cognitiveservices.azure.com/openai/v1/
+# OPENAI_MODEL=gpt-4o-mini
+
+# ── OTel semantic conventions (optional) ──────────────────────────────────────
+# Opt in to experimental gen_ai semantic conventions for structured
+# input/output events (requires strands-agents >= 1.34.0).
+# OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental

--- a/python/agent/strands-agents/agent.py
+++ b/python/agent/strands-agents/agent.py
@@ -1,31 +1,33 @@
 import os
 
-from strands import Agent, tool
-from strands.telemetry import StrandsTelemetry
-from strands_tools import calculator, current_time
-
-# Load environment variables from the .env file
+# Load environment variables first so they're available before any OTel init
 from dotenv import load_dotenv
 
 load_dotenv(override=True)
 
-# Export the Galileo OTel API endpoint for OTel
-os.environ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = os.environ.get("GALILEO_API_ENDPOINT", "https://api.galileo.ai/otel/traces")
+# Set OTLP endpoint from SPLUNK_AO_API_ENDPOINT before OTel initializes
+os.environ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = os.environ.get(
+    "SPLUNK_AO_API_ENDPOINT", "https://api.galileo.ai/otel/traces"
+)
 
-# Export the Galileo OTel headers pointing to the correct API key, project, and log stream
+# Build OTLP headers from Splunk AO env vars
 headers = {
-    "Galileo-API-Key": os.environ["GALILEO_API_KEY"],
-    "project": os.environ["GALILEO_PROJECT"],
-    "logstream": os.environ["GALILEO_LOG_STREAM"],
+    "Galileo-API-Key": os.environ["SPLUNK_AO_API_KEY"],
+    "project": os.environ["SPLUNK_AO_PROJECT"],
+    "logstream": os.environ["SPLUNK_AO_LOG_STREAM"],
 }
-
 os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = ",".join([f"{k}={v}" for k, v in headers.items()])
 
-# Setup telemetry for the Strands agent using Galileo as the OTel backend
+from strands import Agent, tool
+from strands.models.openai import OpenAIModel
+from strands.telemetry import StrandsTelemetry
+from strands_tools import calculator, current_time
+
+# Setup telemetry for the Strands agent using Splunk AO as the OTel backend
 strands_telemetry = StrandsTelemetry()
 strands_telemetry.setup_otlp_exporter()
 
-# Uncomment this line to see the OTel output in the console
+# Uncomment to print spans to stdout for local debugging
 # strands_telemetry.setup_console_exporter()
 
 
@@ -56,9 +58,18 @@ def letter_counter(word: str, letter: str) -> int:
     return word.lower().count(letter.lower())
 
 
+# Use Azure OpenAI via the OpenAI-compatible endpoint
+model = OpenAIModel(
+    model_id=os.environ["OPENAI_MODEL"],
+    client_args={
+        "base_url": os.environ["OPENAI_BASE_URL"],
+        "api_key": os.environ["OPENAI_API_KEY"],
+    },
+)
+
 # Create an agent with tools from the community-driven strands-tools package
 # as well as our custom letter_counter tool
-agent = Agent(tools=[calculator, current_time, letter_counter])
+agent = Agent(model=model, tools=[calculator, current_time, letter_counter])
 
 # Ask the agent a question that uses the available tools
 message = """
@@ -69,3 +80,8 @@ I have 4 requests:
 3. Tell me how many letter R's are in the word "strawberry" 🍓
 """
 agent(message)
+
+# Explicitly flush and shut down the OTel tracer provider.
+# BatchSpanProcessor uses a daemon thread — without shutdown() it may be
+# killed before pending spans are exported.
+strands_telemetry.tracer_provider.shutdown()

--- a/python/agent/strands-agents/requirements.txt
+++ b/python/agent/strands-agents/requirements.txt
@@ -2,5 +2,5 @@ opentelemetry-api
 opentelemetry-exporter-otlp
 opentelemetry-sdk
 python-dotenv
-strands-agents
+strands-agents[openai]
 strands-agents-tools


### PR DESCRIPTION
## Summary

- Replace `from galileo import otel; otel.GalileoSpanProcessor()` with `from splunk_ao.otel import SplunkAOSpanProcessor` — the old import path no longer exists after the SDK rebrand
- Use `Path(__file__).parent / ".env"` for reliable dotenv loading (fixes silent env-var miss when `adk run` sets a different CWD)
- Switch model to `openai/gpt-4o-mini` via LiteLLM so the example works with Azure OpenAI or any OpenAI-compatible endpoint — Gemini is still supported (see README)
- Rename all env vars in `.env.example`:
  | Old | New |
  |-----|-----|
  | `GALILEO_API_KEY` | `SPLUNK_AO_API_KEY` |
  | `GALILEO_PROJECT` | `SPLUNK_AO_PROJECT` |
  | `GALILEO_LOG_STREAM` | `SPLUNK_AO_LOG_STREAM` |
  | `GALILEO_CONSOLE_URL` | `SPLUNK_AO_API_URL` (direct API host, not console URL) |
- Add `opentelemetry-sdk`, `opentelemetry-api`, `opentelemetry-exporter-otlp`, and `litellm>=1.75.5` to `requirements.txt`
- Update README with `SPLUNK_AO_*` variable docs and a self-hosted `SPLUNK_AO_API_URL` note

## Test plan

- [x] Ran `echo "What time is it in London?" | adk run my_agent` against rc0 — agent responded and spans were sent to `agent-observability-api.rc0.signalfx.com`
- [ ] Verify traces appear in rc0 Splunk AO UI under project `google-adk`, log stream `admehra-local`

Made with [Cursor](https://cursor.com)